### PR TITLE
Proxy useful main-process/Node modules to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ I have not looked at [jrudio/meteor-electron](https://github.com/jrudio/meteor-e
 No. By maintaining control over the main process file, we are able to offer cross-platform builds. Allowing users to modify the main process file or NPM packages could easily break our build process.
 
 ### Q: If I can't modify the main process file, how can I create new browser windows, set app notifications and all the other awesome native functionality that Electron gives me?
-Electron exposes these to the client (of the Meteor app in our case) via the [remote module](http://electron.atom.io/docs/v0.31.0/api/remote/)
+
+This project selectively exposes such functionality to the client, in a way that is safe and avoids
+memory leaks, via the `Electron` module--see [`client.js`](client.js). To request that this module
+expose additional functionality, please [submit a pull request](https://github.com/rissem/meteor-electron/pull/new/master)
+or [file an issue](https://github.com/rissem/meteor-electron/issues/new).
 
 ### Q: How do I prevent the Electron app from being built/served in production if for instance I want to do that separately (means forthcoming)?
 

--- a/app/main.js
+++ b/app/main.js
@@ -1,6 +1,8 @@
 var path = require("path");
 var fs = require("fs");
 var createDefaultMenu = require('./menu.js');
+var proxyWindowEvents = require('./proxyWindowEvents');
+
 require('electron-debug')({
     showDevTools: false
 });
@@ -32,7 +34,9 @@ var windowOptions = {
    *  - https://github.com/atom/electron/issues/1753
    */
   webPreferences: {
-    nodeIntegration: false
+    nodeIntegration: false,
+    // See comments at the top of `preload.js`.
+    preload: path.join(__dirname, 'preload.js')
   }
 };
 
@@ -66,6 +70,7 @@ if (electronSettings.frame === false){
 
 app.on("ready", function(){
   mainWindow = new BrowserWindow(windowOptions);
+  proxyWindowEvents(mainWindow);
   mainWindow.focus();
   mainWindow.loadURL(rootUrl);
 });

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "productName": "Electron",
   "main": "main.js",
   "dependencies": {
-    "electron-debug": "^0.5.1"
+    "electron-debug": "^0.5.1",
+    "underscore": "^1.8.3"
   }
 }

--- a/app/preload.js
+++ b/app/preload.js
@@ -8,6 +8,7 @@
  */
 var _ = require('underscore');
 var ipc = require('electron').ipcRenderer;
+var remote = require('electron').remote;
 var shell = require('electron').shell;
 
 /**
@@ -22,6 +23,21 @@ ElectronImplementation = {
    * @param {String} url - The URL to open.
    */
   openExternal: shell.openExternal,
+
+  /**
+   * Determines if the browser window is currently in fullscreen mode.
+   *
+   * "Fullscreen" here refers to the state triggered by toggling the native controls, not that
+   * toggled by the HTML API.
+   *
+   * To detect when the browser window changes fullscreen state, observe the 'enter-full-screen'
+   * and 'leave-full-screen' events using `onWindowEvent`.
+   *
+   * @return {Boolean} `true` if the browser window is in fullscreen mode, `false` otherwise.
+   */
+  isFullScreen: function() {
+    return remote.getCurrentWindow().isFullScreen();
+  },
 
   /**
    * Invokes _callback_ when the specified `BrowserWindow` event is fired.

--- a/app/proxyWindowEvents.js
+++ b/app/proxyWindowEvents.js
@@ -1,0 +1,46 @@
+var _ = require('underscore');
+var ipc = require('ipc-main');
+
+/**
+ * Proxies `BrowserWindow` events to renderer processes as directed by those processes and in a way
+ * that avoids memory leaks.
+ *
+ * For each event that the renderer process wishes to observe, it should send the 'onWindowEvent'
+ * message with the event name as argument:
+ *
+ *   require('electron').ipcRenderer.send('onWindowEvent', 'enter-full-screen')
+ *
+ * The renderer process will then receive the 'triggerWindowEvent' message when the event occurs:
+ *
+ *   require('electron').ipcRenderer.on('triggerWindowEvent', function(event, arg) {
+ *     console.log(arg); // prints 'enter-full-screen'
+ *   });
+ *
+ * This module, in particular the use of the `ipc` vs. `remote` module, is motivated by
+ * https://github.com/atom/electron/blob/master/docs/api/remote.md#passing-callbacks-to-the-main-process.
+ *
+ * @param {BrowserWindow} window - The window whose events to proxy.
+ */
+var proxyWindowEvents = function(window) {
+  var eventsObserved = {};
+
+  ipc.on('onWindowEvent', function(event, arg) {
+    if ((event.sender === window.webContents) && !eventsObserved[arg]) {
+      eventsObserved[arg] = function() {
+        window.webContents.send('triggerWindowEvent', arg);
+      };
+      window.on(arg, eventsObserved[arg]);
+    }
+  });
+
+  // Clear our listeners when the page starts (re)loading i.e. its listeners have been purged.
+  // TODO(wearhere): I'm not sure this is the right event for reload but it seems to work.
+  window.webContents.on('did-start-loading', function() {
+    _.each(eventsObserved, function(listener, event) {
+      window.removeListener(event, listener);
+    });
+    eventsObserved = {};
+  });
+};
+
+module.exports = proxyWindowEvents;

--- a/client.js
+++ b/client.js
@@ -1,5 +1,39 @@
-Electron = {}
+/**
+ * Defines useful client-side functionality.
+ */
+Electron = {
+  /**
+   * @return {Boolean} `true` if the app is running in Electron, `false` otherwise.
+   */
+  isDesktop: function(){
+    return /Electron/.test(navigator.userAgent);
+  },
 
-Electron.isDesktop = function(){
-  return /Electron/.test(navigator.userAgent);
+  // When the app is running in Electron, the following methods will be implemented by `preload.js`.
+  // Stub them out in case the client tries to call them even when not running in Electron.
+
+  /**
+   * Open the given external protocol URL in the desktop's default manner. (For example, http(s):
+   * URLs in the user's default browser.)
+   *
+   * @param {String} url - The URL to open.
+   */
+  openExternal: _.noop,
+
+  /**
+   * Invokes _callback_ when the specified `BrowserWindow` event is fired.
+   *
+   * See https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events for a list
+   * of events.
+   *
+   * @param {String} event - The name of a `BrowserWindow` event.
+   * @param {Function} callback - A function to invoke when `event` is triggered. Takes no arguments
+   *   and returns no value.
+   */
+  onWindowEvent: _.noop
+};
+
+if (typeof ElectronImplementation !== 'undefined') {
+  // The app is running in Electron. Merge the implementations from `preload.js`.
+  _.extend(Electron, ElectronImplementation);
 }

--- a/client.js
+++ b/client.js
@@ -21,6 +21,19 @@ Electron = {
   openExternal: _.noop,
 
   /**
+   * Determines if the browser window is currently in fullscreen mode.
+   *
+   * "Fullscreen" here refers to the state triggered by toggling the native controls, not that
+   * toggled by the HTML API.
+   *
+   * To detect when the browser window changes fullscreen state, observe the 'enter-full-screen'
+   * and 'leave-full-screen' events using `onWindowEvent`.
+   *
+   * @return {Boolean} `true` if the browser window is in fullscreen mode, `false` otherwise.
+   */
+  isFullScreen: _.noop,
+
+  /**
    * Invokes _callback_ when the specified `BrowserWindow` event is fired.
    *
    * See https://github.com/atom/electron/blob/master/docs/api/browser-window.md#events for a list

--- a/package.js
+++ b/package.js
@@ -16,15 +16,18 @@ Npm.depends({
 });
 
 Package.on_use(function (api, where) {
-  api.use(["mongo-livedata", "webapp", "ejson", "underscore"], "server");
+  api.use(["mongo-livedata", "webapp", "ejson"], "server");
+  api.use("underscore", ["server", "client"]);
   api.use(["iron:router"], {weak: true});
   api.addFiles(['server.js'], 'server');
   // When adding new files, also edit `server.js` to write these files into the app directory.
   api.addAssets([
     "app/package.json",
     "app/main.js",
-    "app/menu.js"
+    "app/menu.js",
+    "app/proxyWindowEvents.js",
+    "app/preload.js"
   ], "server");
   api.addFiles(['client.js'], "client");
-  api.export("Electron", ["client", "server"]);
+  api.export("Electron", ["client"]);
 });

--- a/server.js
+++ b/server.js
@@ -60,7 +60,7 @@ function createBinaries() {
   buildDir = path.join(tmpDir, "electron", "builds");
   mkdirp(buildDir);
 
-  ["main.js", "menu.js", "package.json"].forEach(function(filename) {
+  ["main.js", "menu.js", "proxyWindowEvents.js", "preload.js", "package.json"].forEach(function(filename) {
     writeFile(path.join(appDir, filename), Assets.getText(path.join("app", filename)));
   });
 


### PR DESCRIPTION
This is a follow-up to #12—we unfortunately cannot use the `remote` module while having disabled Node integration.

Initial functionality proxied:
- the ability to open URLs in the browser
- the ability to observe `BrowserWindow` events e.g. the app becoming
  full-screen
- the ability to detect whether the app is in full-screen mode or not

This functionality is only a single commit, 4b31c69, it was just too complicated to isolate to its own branch like the other PRs. (Merge the other PRs first and you'll see :).
