### PR TITLE
Simplify the download experience

### DIFF
--- a/server/createBinaries.js
+++ b/server/createBinaries.js
@@ -119,19 +119,25 @@ createBinaries = function() {
   console.log("Build created at", build);
 
 
-  // Package the build for download.
+  // Package the app for download.
+  // TODO(wearhere): make this platform independent
+
+  // Locate the app in a way that's independent of its name (which may have been customized by the user).
+  var app = path.join(build, _.find(fs.readdirSync(build), function(file) {
+    return /\.app$/.test(file);
+  }));
 
   // The auto-updater framework only supports installing ZIP releases:
   // https://github.com/Squirrel/Squirrel.Mac#update-json-format
-  var downloadName = "app-darwin.zip";
+  var downloadName = (appName || "app") + ".zip";
   var compressedDownload = path.join(finalDir, downloadName);
 
   // Use `ditto` to ZIP the app because I couldn't find a good npm module to do it and also that's
   // what a couple of other related projects do:
   // - https://github.com/Squirrel/Squirrel.Mac/blob/8caa2fa2007b29a253f7f5be8fc9f36ace6aa30e/Squirrel/SQRLZipArchiver.h#L24
   // - https://github.com/jenslind/electron-release/blob/4a2a701c18664ec668c3570c3907c0fee72f5e2a/index.js#L109
-  exec('ditto -ck --sequesterRsrc --keepParent "' + build + '" "' + compressedDownload + '"');
+  exec('ditto -ck --sequesterRsrc --keepParent "' + app + '" "' + compressedDownload + '"');
   console.log("Downloadable created at", compressedDownload);
 
-  return build;
+  return app;
 };

--- a/server/launchApp.js
+++ b/server/launchApp.js
@@ -1,5 +1,4 @@
 var isRunning = Meteor.wrapAsync(Npm.require("is-running"));
-var fs = Npm.require('fs');
 var path = Npm.require('path');
 var proc = Npm.require('child_process');
 
@@ -25,7 +24,7 @@ var ProcessManager = {
   }
 };
 
-launchApp = function(build) {
+launchApp = function(app) {
   // Safeguard.
   if (process.env.NODE_ENV !== 'development') return;
 
@@ -35,13 +34,8 @@ launchApp = function(build) {
   }
 
   //TODO make this platform independent
-
-  // Locate the app in a way that's independent of its name (which may have been customized by the user).
-  var app = _.find(fs.readdirSync(build), function(file) {
-    return /\.app$/.test(file);
-  });
-  var electronExecutable = path.join(build, app, "Contents", "MacOS", "Electron");
-  var appDir = path.join(build, app, "Contents", "Resources", "app");
+  var electronExecutable = path.join(app, "Contents", "MacOS", "Electron");
+  var appDir = path.join(app, "Contents", "Resources", "app");
 
   //TODO figure out how to handle case where electron executable or
   //app dir don't exist


### PR DESCRIPTION
By packaging just the app rather than the build folder, which also contains
Electron licenses and version information.
