### PR TITLE
Provide a generic event listener function

### DIFF
--- a/app/proxyWindowEvents.js
+++ b/app/proxyWindowEvents.js
@@ -24,10 +24,10 @@ var ipc = require('ipc-main');
 var proxyWindowEvents = function(window) {
   var eventsObserved = {};
 
-  ipc.on('onWindowEvent', function(event, arg) {
+  ipc.on('observe-window-event', function(event, arg) {
     if ((event.sender === window.webContents) && !eventsObserved[arg]) {
       eventsObserved[arg] = function() {
-        window.webContents.send('triggerWindowEvent', arg);
+        window.webContents.send(arg);
       };
       window.on(arg, eventsObserved[arg]);
     }


### PR DESCRIPTION
This allows the main and renderer (app and web) processes to communicate via IPC, without the web having direct access to the IPC module.
