### PR TITLE
osx local downloadUrl builds to local dir in addition to .meteor-electron

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,2049 +1,2487 @@
 {
   "dependencies": {
-    "electron-packager": {
-      "version": "https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz",
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "from": "abbrev@>=1.0.0 <2.0.0"
+    },
+    "ansi-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "from": "ansi-regex@>=2.0.0 <3.0.0"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "from": "ansi-styles@>=2.2.1 <3.0.0"
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "from": "array-find-index@>=1.0.1 <2.0.0"
+    },
+    "asap": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "from": "asap@>=2.0.3 <2.1.0"
+    },
+    "asar": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-0.8.3.tgz",
+      "from": "asar@>=0.8.2 <0.9.0"
+    },
+    "asn1": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "from": "asn1@0.1.11"
+    },
+    "assert-plus": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "from": "assert-plus@>=0.1.5 <0.2.0"
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "from": "async@>=0.9.0 <0.10.0"
+    },
+    "aws-sign2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "from": "aws-sign2@>=0.5.0 <0.6.0"
+    },
+    "babel-runtime": {
+      "version": "5.8.38",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+      "from": "babel-runtime@>=5.8.20 <6.0.0"
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "from": "balanced-match@>=0.4.1 <0.5.0"
+    },
+    "base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "from": "base64-js@0.0.8"
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "from": "binary@>=0.3.0 <0.4.0"
+    },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "from": "bl@>=0.9.0 <0.10.0",
       "dependencies": {
-        "asar": {
-          "version": "0.8.3",
-          "dependencies": {
-            "chromium-pickle-js": {
-              "version": "0.1.0"
-            },
-            "commander": {
-              "version": "2.3.0"
-            },
-            "cuint": {
-              "version": "0.1.5"
-            },
-            "minimatch": {
-              "version": "2.0.4",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "mksnapshot": {
-              "version": "0.1.0",
-              "dependencies": {
-                "decompress-zip": {
-                  "version": "0.1.0",
-                  "dependencies": {
-                    "binary": {
-                      "version": "0.3.0",
-                      "dependencies": {
-                        "chainsaw": {
-                          "version": "0.1.0",
-                          "dependencies": {
-                            "traverse": {
-                              "version": "0.3.9"
-                            }
-                          }
-                        },
-                        "buffers": {
-                          "version": "0.1.1"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "3.0.8"
-                    },
-                    "mkpath": {
-                      "version": "0.1.0"
-                    },
-                    "nopt": {
-                      "version": "3.0.6",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7"
-                        }
-                      }
-                    },
-                    "q": {
-                      "version": "1.4.1"
-                    },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    },
-                    "touch": {
-                      "version": "0.0.3",
-                      "dependencies": {
-                        "nopt": {
-                          "version": "1.0.10",
-                          "dependencies": {
-                            "abbrev": {
-                              "version": "1.0.7"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "fs-extra": {
-                  "version": "0.18.2",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "3.0.8"
-                    },
-                    "jsonfile": {
-                      "version": "2.2.3"
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.55.0",
-                  "dependencies": {
-                    "bl": {
-                      "version": "0.9.4",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.9.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "0.2.0",
-                      "dependencies": {
-                        "async": {
-                          "version": "0.9.2"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "mime-types": {
-                      "version": "2.0.14",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.12.0"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "qs": {
-                      "version": "2.4.2"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.1"
-                    },
-                    "http-signature": {
-                      "version": "0.10.1",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5"
-                        },
-                        "asn1": {
-                          "version": "0.1.11"
-                        },
-                        "ctype": {
-                          "version": "0.5.3"
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.6.0"
-                    },
-                    "hawk": {
-                      "version": "2.3.1",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "boom": {
-                          "version": "2.10.1"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.5.0"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
-                    },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5"
-                        }
-                      }
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "har-validator": {
-                      "version": "1.8.0",
-                      "dependencies": {
-                        "bluebird": {
-                          "version": "2.10.2"
-                        },
-                        "chalk": {
-                          "version": "1.1.1",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.1.0"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "commander": {
-                          "version": "2.9.0",
-                          "dependencies": {
-                            "graceful-readlink": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.12.3",
-                          "dependencies": {
-                            "generate-function": {
-                              "version": "2.0.0"
-                            },
-                            "generate-object-property": {
-                              "version": "1.2.0",
-                              "dependencies": {
-                                "is-property": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            },
-                            "jsonpointer": {
-                              "version": "2.0.0"
-                            },
-                            "xtend": {
-                              "version": "4.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "from": "readable-stream@>=1.0.26 <1.1.0"
+        }
+      }
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "from": "bluebird@>=2.9.30 <3.0.0"
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "from": "boom@>=2.0.0 <3.0.0"
+    },
+    "brace-expansion": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "from": "brace-expansion@>=1.0.0 <2.0.0"
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "from": "buffers@>=0.1.1 <0.2.0"
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "from": "builtin-modules@>=1.0.0 <2.0.0"
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "from": "camelcase@>=2.0.0 <3.0.0"
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "from": "camelcase-keys@>=2.0.0 <3.0.0"
+    },
+    "caseless": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+      "from": "caseless@>=0.9.0 <0.10.0"
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "from": "chainsaw@>=0.1.0 <0.2.0"
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "from": "chalk@>=1.0.0 <2.0.0"
+    },
+    "chromium-pickle-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
+      "from": "chromium-pickle-js@0.1.0"
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "from": "cliui@>=3.0.3 <4.0.0"
+    },
+    "code-point-at": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+      "from": "code-point-at@>=1.0.0 <2.0.0"
+    },
+    "combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "from": "combined-stream@>=0.0.5 <0.1.0"
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "from": "commander@2.3.0"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "from": "concat-map@0.0.1"
+    },
+    "concat-stream": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+      "from": "concat-stream@1.5.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "from": "isarray@>=1.0.0 <1.1.0"
         },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "from": "readable-stream@>=2.0.0 <2.1.0"
+        }
+      }
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "from": "core-js@>=1.0.0 <2.0.0"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "from": "core-util-is@>=1.0.0 <1.1.0"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "from": "cryptiles@>=2.0.0 <3.0.0"
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "from": "ctype@0.5.3"
+    },
+    "cuint": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.1.5.tgz",
+      "from": "cuint@0.1.5"
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "from": "currently-unhandled@>=0.4.1 <0.5.0"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "from": "debug@>=2.2.0 <3.0.0"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "from": "decamelize@>=1.1.2 <2.0.0"
+    },
+    "decompress-zip": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+      "from": "decompress-zip@0.1.0"
+    },
+    "deep-extend": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+      "from": "deep-extend@>=0.4.0 <0.5.0"
+    },
+    "delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "from": "delayed-stream@0.0.5"
+    },
+    "electron-download": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-1.4.1.tgz",
+      "from": "electron-download@>=1.0.0 <2.0.0"
+    },
+    "electron-packager": {
+      "version": "5.1.1",
+      "resolved": "https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz",
+      "from": "electron-packager@https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz"
+    },
+    "electron-prebuilt": {
+      "version": "0.36.12",
+      "resolved": "https://registry.npmjs.org/electron-prebuilt/-/electron-prebuilt-0.36.12.tgz",
+      "from": "electron-prebuilt@>=0.36.12 <0.37.0",
+      "dependencies": {
         "electron-download": {
-          "version": "1.4.1",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1"
-                }
-              }
-            },
-            "home-path": {
-              "version": "1.0.1"
-            },
-            "nugget": {
-              "version": "1.6.0",
-              "dependencies": {
-                "pretty-bytes": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "get-stdin": {
-                      "version": "4.0.1"
-                    },
-                    "meow": {
-                      "version": "3.6.0",
-                      "dependencies": {
-                        "camelcase-keys": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "2.0.1"
-                            },
-                            "map-obj": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "loud-rejection": {
-                          "version": "1.2.0",
-                          "dependencies": {
-                            "signal-exit": {
-                              "version": "2.1.2"
-                            }
-                          }
-                        },
-                        "normalize-package-data": {
-                          "version": "2.3.5",
-                          "dependencies": {
-                            "hosted-git-info": {
-                              "version": "2.1.4"
-                            },
-                            "is-builtin-module": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "builtin-modules": {
-                                  "version": "1.1.0"
-                                }
-                              }
-                            },
-                            "validate-npm-package-license": {
-                              "version": "3.0.1",
-                              "dependencies": {
-                                "spdx-correct": {
-                                  "version": "1.0.2",
-                                  "dependencies": {
-                                    "spdx-license-ids": {
-                                      "version": "1.1.0"
-                                    }
-                                  }
-                                },
-                                "spdx-expression-parse": {
-                                  "version": "1.0.2",
-                                  "dependencies": {
-                                    "spdx-exceptions": {
-                                      "version": "1.0.4"
-                                    },
-                                    "spdx-license-ids": {
-                                      "version": "1.1.0"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "object-assign": {
-                          "version": "4.0.1"
-                        },
-                        "read-pkg-up": {
-                          "version": "1.0.1",
-                          "dependencies": {
-                            "find-up": {
-                              "version": "1.1.0",
-                              "dependencies": {
-                                "path-exists": {
-                                  "version": "2.1.0"
-                                },
-                                "pinkie-promise": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "2.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "read-pkg": {
-                              "version": "1.1.0",
-                              "dependencies": {
-                                "load-json-file": {
-                                  "version": "1.1.0",
-                                  "dependencies": {
-                                    "graceful-fs": {
-                                      "version": "4.1.2"
-                                    },
-                                    "parse-json": {
-                                      "version": "2.2.0",
-                                      "dependencies": {
-                                        "error-ex": {
-                                          "version": "1.3.0",
-                                          "dependencies": {
-                                            "is-arrayish": {
-                                              "version": "0.2.1"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "pify": {
-                                      "version": "2.3.0"
-                                    },
-                                    "pinkie-promise": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "pinkie": {
-                                          "version": "2.0.1"
-                                        }
-                                      }
-                                    },
-                                    "strip-bom": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "is-utf8": {
-                                          "version": "0.2.0"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "path-type": {
-                                  "version": "1.1.0",
-                                  "dependencies": {
-                                    "graceful-fs": {
-                                      "version": "4.1.2"
-                                    },
-                                    "pify": {
-                                      "version": "2.3.0"
-                                    },
-                                    "pinkie-promise": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "pinkie": {
-                                          "version": "2.0.1"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "redent": {
-                          "version": "1.0.0",
-                          "dependencies": {
-                            "indent-string": {
-                              "version": "2.1.0",
-                              "dependencies": {
-                                "repeating": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "strip-indent": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "trim-newlines": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "progress-stream": {
-                  "version": "1.2.0",
-                  "dependencies": {
-                    "through2": {
-                      "version": "0.2.3",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "2.1.2",
-                          "dependencies": {
-                            "object-keys": {
-                              "version": "0.4.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "speedometer": {
-                      "version": "0.1.4"
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.67.0",
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.4",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "dependencies": {
-                        "async": {
-                          "version": "1.5.0"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "mime-types": {
-                      "version": "2.1.8",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.20.0"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "qs": {
-                      "version": "5.2.0"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.1"
-                    },
-                    "http-signature": {
-                      "version": "1.1.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5"
-                        },
-                        "jsprim": {
-                          "version": "1.2.2",
-                          "dependencies": {
-                            "extsprintf": {
-                              "version": "1.0.2"
-                            },
-                            "json-schema": {
-                              "version": "0.2.2"
-                            },
-                            "verror": {
-                              "version": "1.3.6"
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.7.1",
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3"
-                            },
-                            "assert-plus": {
-                              "version": "0.2.0"
-                            },
-                            "dashdash": {
-                              "version": "1.10.1",
-                              "dependencies": {
-                                "assert-plus": {
-                                  "version": "0.1.5"
-                                }
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.0"
-                            },
-                            "tweetnacl": {
-                              "version": "0.13.2"
-                            },
-                            "jodid25519": {
-                              "version": "1.0.2"
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.0"
-                    },
-                    "hawk": {
-                      "version": "3.1.2",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "boom": {
-                          "version": "2.10.1"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0"
-                    },
-                    "har-validator": {
-                      "version": "2.0.3",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.1.0"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "commander": {
-                          "version": "2.9.0",
-                          "dependencies": {
-                            "graceful-readlink": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.12.3",
-                          "dependencies": {
-                            "generate-function": {
-                              "version": "2.0.0"
-                            },
-                            "generate-object-property": {
-                              "version": "1.2.0",
-                              "dependencies": {
-                                "is-property": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            },
-                            "jsonpointer": {
-                              "version": "2.0.0"
-                            },
-                            "xtend": {
-                              "version": "4.0.1"
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "single-line-log": {
-                  "version": "0.4.1"
-                },
-                "throttleit": {
-                  "version": "0.0.2"
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0"
-            },
-            "rc": {
-              "version": "1.1.5",
-              "dependencies": {
-                "deep-extend": {
-                  "version": "0.4.0"
-                },
-                "ini": {
-                  "version": "1.3.4"
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4"
-                }
-              }
-            }
-          }
-        },
-        "extract-zip": {
-          "version": "1.3.0",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0"
-            },
-            "concat-stream": {
-              "version": "1.5.0",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "typedarray": {
-                  "version": "0.0.6"
-                },
-                "readable-stream": {
-                  "version": "2.0.4",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4"
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8"
-                }
-              }
-            },
-            "yauzl": {
-              "version": "2.3.1",
-              "dependencies": {
-                "fd-slicer": {
-                  "version": "1.0.1"
-                },
-                "pend": {
-                  "version": "1.2.0"
-                }
-              }
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0"
-        },
-        "mv": {
-          "version": "2.1.1"
-        },
-        "plist": {
-          "version": "1.2.0",
-          "dependencies": {
-            "base64-js": {
-              "version": "0.0.8"
-            },
-            "xmlbuilder": {
-              "version": "4.0.0",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1"
-                }
-              }
-            },
-            "xmldom": {
-              "version": "0.1.19"
-            },
-            "util-deprecate": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "rcedit": {
-          "version": "0.3.0"
-        },
-        "run-series": {
-          "version": "1.1.4"
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-2.2.1.tgz",
+          "from": "electron-download@>=2.0.0 <3.0.0"
         }
       }
     },
     "electron-rebuild": {
-      "version": "1.0.1",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.2.1.tgz",
+      "from": "electron-rebuild@1.2.1",
       "dependencies": {
-        "babel-runtime": {
-          "version": "5.8.35",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.6"
-            }
-          }
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "from": "glob@>=6.0.3 <7.0.0"
         },
-        "lodash": {
-          "version": "3.10.1"
-        },
-        "npm": {
-          "version": "2.14.18",
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "from": "rimraf@>=2.5.0 <3.0.0",
           "dependencies": {
-            "abbrev": {
-              "version": "1.0.7"
-            },
-            "ansi": {
-              "version": "0.3.1"
-            },
-            "ansicolors": {
-              "version": "0.3.2"
-            },
-            "ansistyles": {
-              "version": "0.1.3"
-            },
-            "archy": {
-              "version": "1.0.0"
-            },
-            "async-some": {
-              "version": "1.0.2"
-            },
-            "block-stream": {
-              "version": "0.0.8"
-            },
-            "char-spinner": {
-              "version": "1.0.1"
-            },
-            "chmodr": {
-              "version": "1.0.2"
-            },
-            "chownr": {
-              "version": "1.0.1"
-            },
-            "cmd-shim": {
-              "version": "2.0.1",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.8"
-                }
-              }
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "dependencies": {
-                "wcwidth": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "defaults": {
-                      "version": "1.0.3",
-                      "dependencies": {
-                        "clone": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.10",
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4"
-                }
-              }
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.3"
-                }
-              }
-            },
-            "editor": {
-              "version": "1.0.0"
-            },
-            "fs-vacuum": {
-              "version": "1.2.7"
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.8",
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5"
-                }
-              }
-            },
-            "fstream": {
-              "version": "1.0.8"
-            },
-            "fstream-npm": {
-              "version": "1.0.7",
-              "dependencies": {
-                "fstream-ignore": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "github-url-from-git": {
-              "version": "1.4.0"
-            },
-            "github-url-from-username-repo": {
-              "version": "1.0.2"
-            },
             "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.3"
-            },
-            "hosted-git-info": {
-              "version": "2.1.4"
-            },
-            "inflight": {
-              "version": "1.0.4"
-            },
-            "inherits": {
-              "version": "2.0.1"
-            },
-            "ini": {
-              "version": "1.3.4"
-            },
-            "init-package-json": {
-              "version": "1.9.3",
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "promzard": {
-                  "version": "0.3.0"
-                }
-              }
-            },
-            "lockfile": {
-              "version": "1.0.1"
-            },
-            "lru-cache": {
-              "version": "3.2.0",
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.1"
-                }
-              }
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "from": "glob@>=7.0.5 <8.0.0"
             },
             "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8"
-                }
-              }
-            },
-            "node-gyp": {
-              "version": "3.2.1",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.2",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "are-we-there-yet": {
-                      "version": "1.0.5",
-                      "dependencies": {
-                        "delegates": {
-                          "version": "0.1.0"
-                        }
-                      }
-                    },
-                    "gauge": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "has-unicode": {
-                          "version": "1.0.1"
-                        },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-array": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "array-index": {
-                      "version": "0.1.1",
-                      "dependencies": {
-                        "debug": {
-                          "version": "2.2.0",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6"
-            },
-            "normalize-git-url": {
-              "version": "3.0.1"
-            },
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "dependencies": {
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2"
-            },
-            "npm-install-checks": {
-              "version": "1.0.6",
-              "dependencies": {
-                "npmlog": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "are-we-there-yet": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "delegates": {
-                          "version": "0.1.0"
-                        }
-                      }
-                    },
-                    "gauge": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "has-unicode": {
-                          "version": "1.0.1"
-                        },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "npm-package-arg": {
-              "version": "4.1.0"
-            },
-            "npm-registry-client": {
-              "version": "7.0.9",
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.4",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "retry": {
-                  "version": "0.8.0"
-                }
-              }
-            },
-            "npm-user-validate": {
-              "version": "0.1.2"
-            },
-            "npmlog": {
-              "version": "2.0.2",
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.0.6",
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "gauge": {
-                  "version": "1.2.5",
-                  "dependencies": {
-                    "has-unicode": {
-                      "version": "2.0.0"
-                    },
-                    "lodash.pad": {
-                      "version": "3.2.2",
-                      "dependencies": {
-                        "lodash.repeat": {
-                          "version": "3.1.2"
-                        }
-                      }
-                    },
-                    "lodash.padleft": {
-                      "version": "3.1.1",
-                      "dependencies": {
-                        "lodash._basetostring": {
-                          "version": "3.0.1"
-                        },
-                        "lodash._createpadding": {
-                          "version": "3.6.1",
-                          "dependencies": {
-                            "lodash.repeat": {
-                              "version": "3.1.2"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lodash.padright": {
-                      "version": "3.1.1",
-                      "dependencies": {
-                        "lodash._basetostring": {
-                          "version": "3.0.1"
-                        },
-                        "lodash._createpadding": {
-                          "version": "3.6.1",
-                          "dependencies": {
-                            "lodash.repeat": {
-                              "version": "3.1.2"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3"
-            },
-            "opener": {
-              "version": "1.4.1"
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.0"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.1"
-            },
-            "read": {
-              "version": "1.0.7",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "dependencies": {
-                "debuglog": {
-                  "version": "1.0.1"
-                },
-                "readdir-scoped-modules": {
-                  "version": "1.0.2"
-                },
-                "util-extend": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.3",
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "json-parse-helpfulerror": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "jju": {
-                      "version": "1.2.1"
-                    }
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                }
-              }
-            },
-            "realize-package-specifier": {
-              "version": "3.0.1"
-            },
-            "request": {
-              "version": "2.69.0",
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "aws4": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3"
-                    }
-                  }
-                },
-                "bl": {
-                  "version": "1.0.2",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.5",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.11.0"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0"
-                },
-                "forever-agent": {
-                  "version": "0.6.1"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.2"
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.1.0"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.4"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0"
-                        },
-                        "supports-color": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.12.4",
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0"
-                        },
-                        "xtend": {
-                          "version": "4.0.1"
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2"
-                        },
-                        "json-schema": {
-                          "version": "0.2.2"
-                        },
-                        "verror": {
-                          "version": "1.3.6"
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.7.3",
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3"
-                        },
-                        "dashdash": {
-                          "version": "1.12.2"
-                        },
-                        "jsbn": {
-                          "version": "0.1.0"
-                        },
-                        "tweetnacl": {
-                          "version": "0.13.3"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0"
-                },
-                "isstream": {
-                  "version": "0.1.2"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "mime-types": {
-                  "version": "2.1.9",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.21.0"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7"
-                },
-                "oauth-sign": {
-                  "version": "0.8.1"
-                },
-                "qs": {
-                  "version": "6.0.2"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "tough-cookie": {
-                  "version": "2.2.1"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2"
-                }
-              }
-            },
-            "retry": {
-              "version": "0.9.0"
-            },
-            "rimraf": {
-              "version": "2.5.1",
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.1.0"
-            },
-            "sha": {
-              "version": "2.0.1",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.2",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "slide": {
-              "version": "1.1.6"
-            },
-            "sorted-object": {
-              "version": "1.0.0"
-            },
-            "spdx-license-ids": {
-              "version": "1.2.0"
-            },
-            "tar": {
-              "version": "2.2.1"
-            },
-            "text-table": {
-              "version": "0.2.0"
-            },
-            "uid-number": {
-              "version": "0.0.6"
-            },
-            "umask": {
-              "version": "1.1.0"
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "dependencies": {
-                "spdx-correct": {
-                  "version": "1.0.2"
-                },
-                "spdx-expression-parse": {
-                  "version": "1.0.2",
-                  "dependencies": {
-                    "spdx-exceptions": {
-                      "version": "1.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "2.2.2",
-              "dependencies": {
-                "builtins": {
-                  "version": "0.0.7"
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.4",
-              "dependencies": {
-                "is-absolute": {
-                  "version": "0.1.7",
-                  "dependencies": {
-                    "is-relative": {
-                      "version": "0.1.3"
-                    }
-                  }
-                },
-                "isexe": {
-                  "version": "1.1.1"
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.1"
-            },
-            "write-file-atomic": {
-              "version": "1.1.4"
-            },
-            "ansi-regex": {
-              "version": "2.0.0"
-            },
-            "imurmurhash": {
-              "version": "0.1.4"
-            },
-            "strip-ansi": {
-              "version": "3.0.0"
-            }
-          }
-        },
-        "nslog": {
-          "version": "3.0.0",
-          "dependencies": {
-            "nan": {
-              "version": "2.2.0"
-            }
-          }
-        },
-        "promise": {
-          "version": "7.1.1",
-          "dependencies": {
-            "asap": {
-              "version": "2.0.3"
-            }
-          }
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "dependencies": {
-            "camelcase": {
-              "version": "2.1.0"
-            },
-            "cliui": {
-              "version": "3.1.0",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "wrap-ansi": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.1.2",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.4"
-                }
-              }
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "dependencies": {
-                "lcid": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "invert-kv": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "window-size": {
-              "version": "0.1.4"
-            },
-            "y18n": {
-              "version": "3.2.0"
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "from": "minimatch@>=3.0.2 <4.0.0"
             }
           }
         }
       }
     },
+    "error-ex": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+      "from": "error-ex@>=1.2.0 <2.0.0"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+    },
+    "extract-zip": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+      "from": "extract-zip@>=1.0.3 <2.0.0",
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "from": "debug@0.7.4"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "minimist@0.0.8"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@0.5.0"
+        }
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "from": "fd-slicer@>=1.0.1 <1.1.0"
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "from": "find-up@>=1.0.0 <2.0.0",
+      "dependencies": {
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "from": "path-exists@>=2.0.0 <3.0.0"
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "from": "forever-agent@>=0.6.0 <0.7.0"
+    },
+    "form-data": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+      "from": "form-data@>=0.2.0 <0.3.0"
+    },
+    "fs-extra": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+      "from": "fs-extra@0.18.2"
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "from": "fs.realpath@>=1.0.0 <2.0.0"
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "from": "generate-function@>=2.0.0 <3.0.0"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "from": "generate-object-property@>=1.1.0 <2.0.0"
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "from": "get-stdin@>=4.0.1 <5.0.0"
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "from": "glob@>=5.0.5 <6.0.0"
+    },
+    "graceful-fs": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "from": "graceful-fs@>=3.0.0 <4.0.0"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "from": "graceful-readlink@>=1.0.0"
+    },
+    "har-validator": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+      "from": "har-validator@>=1.4.0 <2.0.0",
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "from": "commander@>=2.8.1 <3.0.0"
+        }
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "from": "has-ansi@>=2.0.0 <3.0.0"
+    },
+    "hawk": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "from": "hawk@>=2.3.0 <2.4.0"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "from": "hoek@>=2.0.0 <3.0.0"
+    },
+    "home-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz",
+      "from": "home-path@>=1.0.1 <2.0.0"
+    },
+    "hosted-git-info": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+      "from": "hosted-git-info@>=2.1.4 <3.0.0"
+    },
+    "http-signature": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "from": "http-signature@>=0.10.0 <0.11.0"
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "from": "indent-string@>=2.1.0 <3.0.0"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "from": "inflight@>=1.0.4 <2.0.0"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "from": "inherits@>=2.0.0 <3.0.0"
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "from": "ini@>=1.3.0 <1.4.0"
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "from": "invert-kv@>=1.0.0 <2.0.0"
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "from": "is-arrayish@>=0.2.1 <0.3.0"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "from": "is-builtin-module@>=1.0.0 <2.0.0"
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "from": "is-finite@>=1.0.0 <2.0.0"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0"
+    },
+    "is-my-json-valid": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+      "from": "is-my-json-valid@>=2.12.0 <3.0.0"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "from": "is-property@>=1.0.0 <2.0.0"
+    },
     "is-running": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-running/-/is-running-1.0.5.tgz",
+      "from": "is-running@1.0.5"
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "from": "is-utf8@>=0.2.0 <0.3.0"
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "from": "isarray@0.0.1"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "from": "isstream@>=0.1.1 <0.2.0"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "from": "jsonfile@>=2.0.0 <3.0.0",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+          "from": "graceful-fs@>=4.1.6 <5.0.0"
+        }
+      }
+    },
+    "jsonpointer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+      "from": "jsonpointer@>=4.0.0 <5.0.0"
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "from": "lcid@>=1.0.0 <2.0.0"
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+          "from": "graceful-fs@>=4.1.2 <5.0.0"
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "from": "lodash@>=3.5.0 <4.0.0"
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "from": "loud-rejection@>=1.0.0 <2.0.0"
     },
     "lucy-dirsum": {
-      "version": "https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz"
+      "version": "0.1.1",
+      "resolved": "https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz",
+      "from": "lucy-dirsum@https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz"
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "from": "map-obj@>=1.0.1 <2.0.0"
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "from": "meow@>=3.1.0 <4.0.0"
+    },
+    "mime-db": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+      "from": "mime-db@>=1.12.0 <1.13.0"
+    },
+    "mime-types": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+      "from": "mime-types@>=2.0.1 <2.1.0"
+    },
+    "minimatch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+      "from": "minimatch@2.0.4"
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "from": "minimist@>=1.1.1 <2.0.0"
     },
     "mkdirp": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "from": "mkdirp@0.5.1",
       "dependencies": {
         "minimist": {
-          "version": "0.0.8"
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "minimist@0.0.8"
         }
       }
     },
-    "ncp": {
-      "version": "2.0.0"
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "from": "mkpath@>=0.1.0 <0.2.0"
     },
-    "rimraf": {
-      "version": "2.4.4",
+    "mksnapshot": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
+      "from": "mksnapshot@0.1.0"
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "from": "ms@0.7.1"
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "from": "mv@>=2.0.3 <3.0.0"
+    },
+    "nan": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+      "from": "nan@>=2.0.0 <3.0.0"
+    },
+    "natives": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "from": "natives@>=1.1.0 <2.0.0"
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "from": "ncp@2.0.0"
+    },
+    "node-uuid": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "from": "node-uuid@>=1.4.0 <1.5.0"
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "from": "nopt@>=3.0.1 <4.0.0"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+      "from": "normalize-package-data@>=2.3.4 <3.0.0"
+    },
+    "npm": {
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-3.10.8.tgz",
+      "from": "npm@>=3.5.3 <4.0.0",
       "dependencies": {
-        "glob": {
-          "version": "5.0.15",
+        "abbrev": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "from": "abbrev@1.0.9"
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+          "from": "ansi-regex@2.0.0"
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "from": "ansicolors@>=0.3.2 <0.4.0"
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "from": "ansistyles@>=0.1.3 <0.2.0"
+        },
+        "aproba": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+          "from": "aproba@>=1.0.3 <1.1.0"
+        },
+        "archy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "from": "archy@>=1.0.0 <1.1.0"
+        },
+        "asap": {
+          "version": "2.0.4",
+          "resolved": "https://unpm.uberinternal.com/asap/-/asap-2.0.4.tgz",
+          "from": "asap@latest"
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "from": "chownr@>=1.0.1 <1.1.0"
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+          "from": "cmd-shim@2.0.2"
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "from": "columnify@1.5.4",
           "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
+            "wcwidth": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+              "from": "wcwidth@>=1.0.0 <2.0.0",
               "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
+                "defaults": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                  "from": "defaults@>=1.0.0 <2.0.0",
                   "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
+                    "clone": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                      "from": "clone@>=1.0.2 <2.0.0"
                     }
                   }
                 }
               }
-            },
-            "once": {
-              "version": "1.3.3",
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+          "from": "config-chain@1.1.10",
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "from": "proto-list@>=1.2.1 <1.3.0"
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "from": "debuglog@1.0.1"
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "from": "dezalgo@>=1.0.3 <1.1.0"
+        },
+        "editor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "from": "editor@>=1.0.0 <1.1.0"
+        },
+        "fs-vacuum": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
+          "from": "fs-vacuum@latest"
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.8",
+          "from": "fs-write-stream-atomic@1.0.8"
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+          "from": "fstream@>=1.0.10 <1.1.0"
+        },
+        "fstream-npm": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz",
+          "from": "fstream-npm@latest",
+          "dependencies": {
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "from": "fstream-ignore@>=1.0.0 <2.0.0",
               "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
+                "minimatch": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "from": "minimatch@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "from": "glob@7.0.6",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "from": "fs.realpath@>=1.0.0 <2.0.0"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "from": "balanced-match@>=0.4.1 <0.5.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0"
             }
           }
+        },
+        "graceful-fs": {
+          "version": "4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+          "from": "graceful-fs@4.1.6"
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "from": "has-unicode@>=2.0.0 <2.1.0"
+        },
+        "hosted-git-info": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+          "from": "hosted-git-info@latest"
+        },
+        "iferr": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+          "from": "iferr@>=0.1.5 <0.2.0"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "from": "imurmurhash@>=0.1.4 <0.2.0"
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+          "from": "inflight@latest"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "from": "inherits@2.0.3"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "from": "ini@>=1.3.4 <1.4.0"
+        },
+        "init-package-json": {
+          "version": "1.9.4",
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
+          "from": "init-package-json@latest",
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "from": "glob@>=6.0.0 <7.0.0",
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "promzard": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "from": "promzard@>=0.3.0 <0.4.0"
+            }
+          }
+        },
+        "lockfile": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+          "from": "lockfile@>=1.0.1 <1.1.0"
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "from": "lodash._baseindexof@3.1.0"
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "from": "lodash._baseuniq@latest",
+          "dependencies": {
+            "lodash._createset": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+              "from": "lodash._createset@>=4.0.0 <4.1.0"
+            },
+            "lodash._root": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+              "from": "lodash._root@>=3.0.0 <3.1.0"
+            }
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "from": "lodash._bindcallback@3.0.1"
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "from": "lodash._cacheindexof@3.0.2"
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "from": "lodash._createcache@3.1.2"
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "from": "lodash._getnative@3.9.1"
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "from": "lodash.clonedeep@4.5.0"
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "from": "lodash.restparam@3.6.1"
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "from": "lodash.union@4.6.0"
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "from": "lodash.uniq@4.5.0"
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "from": "lodash.without@4.4.0"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+          "from": "node-gyp@latest",
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "from": "balanced-match@>=0.4.1 <0.5.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "npmlog": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "from": "are-we-there-yet@~1.1.2",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "from": "delegates@^1.0.0"
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "from": "console-control-strings@~1.1.0"
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "from": "gauge@~2.6.0",
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "from": "has-color@^0.1.7"
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                      "from": "object-assign@^4.1.0"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                      "from": "signal-exit@^3.0.0"
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "from": "string-width@^1.0.1",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "from": "code-point-at@^1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@^1.0.0"
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "from": "is-fullwidth-code-point@^1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@^1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                      "from": "wide-align@^1.1.0"
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "from": "set-blocking@~2.0.0"
+                }
+              }
+            },
+            "path-array": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+              "from": "path-array@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "array-index": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+                  "from": "array-index@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "from": "ms@0.7.1"
+                        }
+                      }
+                    },
+                    "es6-symbol": {
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+                      "from": "es6-symbol@>=3.0.2 <4.0.0",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                          "from": "d@>=0.1.1 <0.2.0"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.12",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+                          "from": "es5-ext@>=0.10.11 <0.11.0",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                              "from": "es6-iterator@>=2.0.0 <3.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "from": "nopt@>=3.0.6 <3.1.0"
+        },
+        "normalize-git-url": {
+          "version": "3.0.2",
+          "from": "normalize-git-url@>=3.0.2 <3.1.0"
+        },
+        "normalize-package-data": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+          "from": "normalize-package-data@>=2.3.5 <2.4.0",
+          "dependencies": {
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                  "from": "builtin-modules@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "from": "npm-cache-filename@>=1.0.2 <1.1.0"
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "from": "npm-install-checks@3.0.0"
+        },
+        "npm-package-arg": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
+          "from": "npm-package-arg@4.2.0"
+        },
+        "npm-registry-client": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+          "from": "npm-registry-client@7.2.1",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+              "from": "concat-stream@>=1.5.2 <2.0.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0"
+                    }
+                  }
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@>=0.0.5 <0.1.0"
+                }
+              }
+            },
+            "npmlog": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+              "from": "npmlog@>=2.0.0 <2.1.0||>=3.1.0 <3.2.0",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "from": "are-we-there-yet@~1.1.2",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "from": "delegates@^1.0.0"
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "from": "console-control-strings@~1.1.0"
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "from": "gauge@~2.6.0",
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "from": "has-color@^0.1.7"
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                      "from": "object-assign@^4.1.0"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                      "from": "signal-exit@^3.0.0"
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "from": "string-width@^1.0.1",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "from": "code-point-at@^1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@^1.0.0"
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "from": "is-fullwidth-code-point@^1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@^1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                      "from": "wide-align@^1.1.0"
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "from": "set-blocking@~2.0.0"
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+              "from": "retry@>=0.10.0 <0.11.0"
+            }
+          }
+        },
+        "npm-user-validate": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+          "from": "npm-user-validate@0.1.5"
+        },
+        "npmlog": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+          "from": "npmlog@4.0.0",
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.2",
+              "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "from": "delegates@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "from": "console-control-strings@>=1.1.0 <1.2.0"
+            },
+            "gauge": {
+              "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+              "from": "gauge@>=2.6.0 <2.7.0",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "from": "has-color@>=0.1.7 <0.2.0"
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                  "from": "object-assign@>=4.0.1 <5.0.0"
+                },
+                "signal-exit": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                  "from": "signal-exit@>=3.0.0 <4.0.0"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "from": "string-width@>=1.0.1 <2.0.0",
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "from": "number-is-nan@^1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                  "from": "wide-align@>=1.1.0 <2.0.0"
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "from": "set-blocking@>=2.0.0 <2.1.0"
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "from": "once@1.4.0"
+        },
+        "opener": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
+          "from": "opener@>=1.4.1 <1.5.0"
+        },
+        "osenv": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+          "from": "osenv@>=0.1.3 <0.2.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+              "from": "os-homedir@>=1.0.0 <2.0.0"
+            },
+            "os-tmpdir": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+              "from": "os-tmpdir@>=1.0.0 <2.0.0"
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+          "from": "path-is-inside@>=1.0.1 <1.1.0"
+        },
+        "read": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "from": "read@>=1.0.7 <1.1.0",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+              "from": "mute-stream@>=0.0.4 <0.1.0"
+            }
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+          "from": "read-cmd-shim@>=1.0.1 <1.1.0"
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "from": "read-installed@>=4.0.3 <4.1.0",
+          "dependencies": {
+            "util-extend": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+              "from": "util-extend@>=1.0.1 <2.0.0"
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+          "from": "read-package-json@>=2.0.3 <2.1.0",
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "from": "glob@>=6.0.0 <7.0.0",
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "json-parse-helpfulerror": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+              "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
+              "dependencies": {
+                "jju": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                  "from": "jju@>=1.1.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz",
+          "from": "read-package-tree@>=5.1.4 <5.2.0"
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "from": "readable-stream@2.1.5",
+          "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "from": "buffer-shims@>=1.0.0 <2.0.0"
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "from": "isarray@>=1.0.0 <1.1.0"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "from": "util-deprecate@>=1.0.1 <1.1.0"
+            }
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+          "from": "readdir-scoped-modules@1.0.2"
+        },
+        "realize-package-specifier": {
+          "version": "3.0.3",
+          "from": "realize-package-specifier@>=3.0.2 <3.1.0"
+        },
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "from": "request@>=2.74.0 <2.75.0",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "from": "aws-sign2@>=0.6.0 <0.7.0"
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+              "from": "aws4@>=1.2.1 <2.0.0"
+            },
+            "bl": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "from": "bl@>=1.1.2 <1.2.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <1.1.0"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "from": "caseless@>=0.11.0 <0.12.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@>=3.0.0 <3.1.0"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "from": "forever-agent@>=0.6.1 <0.7.0"
+            },
+            "form-data": {
+              "version": "1.0.0-rc4",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+              "from": "form-data@>=1.0.0-rc4 <1.1.0",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "from": "async@>=1.5.2 <2.0.0"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "from": "has-ansi@>=2.0.0 <3.0.0"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "from": "supports-color@>=2.0.0 <3.0.0"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "from": "commander@>=2.9.0 <3.0.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "from": "generate-function@>=2.0.0 <3.0.0"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "from": "is-property@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "from": "jsonpointer@2.0.0"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "from": "pinkie@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "from": "boom@>=2.0.0 <3.0.0"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "from": "cryptiles@>=2.0.0 <3.0.0"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "from": "hoek@>=2.0.0 <3.0.0"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "from": "assert-plus@>=0.2.0 <0.3.0"
+                },
+                "jsprim": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "from": "extsprintf@1.0.2"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "from": "json-schema@0.2.2"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "from": "verror@1.3.6"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.9.2",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "from": "asn1@>=0.2.3 <0.3.0"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "from": "assert-plus@>=1.0.0 <2.0.0"
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                      "from": "dashdash@>=1.12.0 <2.0.0"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0"
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "from": "getpass@>=0.1.1 <0.2.0"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "from": "jodid25519@>=1.0.0 <2.0.0"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "from": "jsbn@>=0.1.0 <0.2.0"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "from": "tweetnacl@>=0.13.0 <0.14.0"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "from": "is-typedarray@>=1.0.0 <1.1.0"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.2 <0.2.0"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "from": "mime-db@>=1.23.0 <1.24.0"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "from": "node-uuid@>=1.4.7 <1.5.0"
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "from": "oauth-sign@>=0.8.1 <0.9.0"
+            },
+            "qs": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+              "from": "qs@>=6.2.0 <6.3.0"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0"
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "from": "tough-cookie@>=2.3.0 <2.4.0"
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+          "from": "retry@0.10.0"
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "from": "rimraf@2.5.4"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "from": "semver@5.3.0"
+        },
+        "sha": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+          "from": "sha@>=2.0.1 <2.1.0"
+        },
+        "slide": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@>=1.1.6 <1.2.0"
+        },
+        "sorted-object": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
+          "from": "sorted-object@latest"
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "from": "strip-ansi@*"
+        },
+        "tar": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "from": "tar@>=2.2.1 <2.3.0",
+          "dependencies": {
+            "block-stream": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+              "from": "block-stream@*"
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0"
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "from": "uid-number@0.0.6"
+        },
+        "umask": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "from": "umask@>=1.1.0 <1.2.0"
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+          "from": "unique-filename@>=1.1.0 <2.0.0",
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "from": "unique-slug@>=2.0.0 <3.0.0"
+            }
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "from": "unpipe@>=1.0.0 <1.1.0"
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "from": "validate-npm-package-license@3.0.1",
+          "dependencies": {
+            "spdx-correct": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "from": "spdx-correct@>=1.0.0 <1.1.0",
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
+                  "from": "spdx-license-ids@>=1.0.2 <2.0.0"
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+              "dependencies": {
+                "spdx-exceptions": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                  "from": "spdx-exceptions@>=1.0.4 <2.0.0"
+                },
+                "spdx-license-ids": {
+                  "version": "1.2.0",
+                  "from": "spdx-license-ids@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+          "from": "validate-npm-package-name@>=2.2.2 <2.3.0",
+          "dependencies": {
+            "builtins": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+              "from": "builtins@0.0.7"
+            }
+          }
+        },
+        "which": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+          "from": "which@1.2.11",
+          "dependencies": {
+            "isexe": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+              "from": "isexe@>=1.1.1 <2.0.0"
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "from": "wrappy@latest"
+        },
+        "write-file-atomic": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
+          "from": "write-file-atomic@1.2.0"
         }
       }
     },
+    "nslog": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nslog/-/nslog-3.0.0.tgz",
+      "from": "nslog@>=3.0.0 <4.0.0"
+    },
+    "nugget": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
+      "from": "nugget@>=1.5.1 <2.0.0"
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "from": "number-is-nan@>=1.0.0 <2.0.0"
+    },
+    "oauth-sign": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+      "from": "oauth-sign@>=0.6.0 <0.7.0"
+    },
+    "object-assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "from": "object-assign@>=4.0.1 <5.0.0"
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "from": "object-keys@>=0.4.0 <0.5.0"
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "from": "once@>=1.3.0 <2.0.0"
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "from": "os-locale@>=1.4.0 <2.0.0"
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "from": "parse-json@>=2.2.0 <3.0.0"
+    },
+    "path-exists": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+      "from": "path-exists@>=1.0.0 <2.0.0"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "from": "path-type@>=1.0.0 <2.0.0",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+          "from": "graceful-fs@>=4.1.2 <5.0.0"
+        }
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "from": "pend@>=1.2.0 <1.3.0"
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "from": "pify@>=2.0.0 <3.0.0"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "from": "pinkie@>=2.0.0 <3.0.0"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0"
+    },
+    "plist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+      "from": "plist@>=1.1.0 <2.0.0"
+    },
+    "pretty-bytes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "from": "pretty-bytes@>=1.0.2 <2.0.0"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+    },
+    "progress-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "from": "progress-stream@>=1.1.0 <2.0.0"
+    },
+    "promise": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "from": "promise@>=7.1.1 <8.0.0"
+    },
+    "q": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "from": "q@>=1.1.2 <2.0.0"
+    },
+    "qs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+      "from": "qs@>=2.4.0 <2.5.0"
+    },
+    "rc": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+      "from": "rc@>=1.1.2 <2.0.0"
+    },
+    "rcedit": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.3.0.tgz",
+      "from": "rcedit@>=0.3.0 <0.4.0"
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "from": "read-pkg@>=1.0.0 <2.0.0"
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "from": "read-pkg-up@>=1.0.1 <2.0.0"
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "from": "readable-stream@>=1.1.8 <2.0.0"
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "from": "redent@>=1.0.0 <2.0.0"
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "from": "repeating@>=2.0.0 <3.0.0"
+    },
+    "request": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+      "from": "request@2.55.0"
+    },
+    "rimraf": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+      "from": "rimraf@2.4.4"
+    },
+    "run-series": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
+      "from": "run-series@>=1.1.1 <2.0.0"
+    },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+      "from": "semver@5.1.0"
+    },
+    "signal-exit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+      "from": "signal-exit@>=3.0.0 <4.0.0"
+    },
+    "single-line-log": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
+      "from": "single-line-log@>=0.4.1 <0.5.0"
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "from": "sntp@>=1.0.0 <2.0.0"
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "from": "spdx-correct@>=1.0.0 <1.1.0"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "from": "spdx-expression-parse@>=1.0.0 <1.1.0"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "from": "spdx-license-ids@>=1.0.2 <2.0.0"
+    },
+    "speedometer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "from": "speedometer@>=0.1.2 <0.2.0"
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "from": "string-width@>=1.0.1 <2.0.0"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "from": "string_decoder@>=0.10.0 <0.11.0"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "from": "stringstream@>=0.0.4 <0.1.0"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "from": "strip-ansi@>=3.0.0 <4.0.0"
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "from": "strip-bom@>=2.0.0 <3.0.0"
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "from": "strip-indent@>=1.0.1 <2.0.0"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "from": "strip-json-comments@>=1.0.4 <1.1.0"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "from": "supports-color@>=2.0.0 <3.0.0"
+    },
+    "throttleit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "from": "throttleit@0.0.2"
+    },
+    "through2": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "from": "through2@>=0.2.3 <0.3.0",
+      "dependencies": {
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "from": "xtend@>=2.1.1 <2.2.0"
+        }
+      }
+    },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "from": "touch@0.0.3",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0"
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+      "from": "tough-cookie@>=0.12.0"
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "from": "traverse@>=0.3.0 <0.4.0"
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "from": "trim-newlines@>=1.0.0 <2.0.0"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "from": "tunnel-agent@>=0.4.0 <0.5.0"
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "from": "typedarray@>=0.0.5 <0.1.0"
     },
     "url-join": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "from": "url-join@0.0.1"
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "from": "util-deprecate@>=1.0.1 <1.1.0"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "from": "validate-npm-package-license@>=3.0.1 <4.0.0"
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "from": "window-size@>=0.1.4 <0.2.0"
+    },
+    "wrap-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
+      "from": "wrap-ansi@>=2.0.0 <3.0.0"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "from": "wrappy@>=1.0.0 <2.0.0"
+    },
+    "xmlbuilder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+      "from": "xmlbuilder@4.0.0"
+    },
+    "xmldom": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
+      "from": "xmldom@>=0.1.0 <0.2.0"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "from": "xtend@>=4.0.0 <5.0.0"
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "from": "y18n@>=3.2.0 <4.0.0"
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "from": "yargs@>=3.31.0 <4.0.0"
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "from": "yauzl@2.4.1"
     }
   }
 }

--- a/app/main.js
+++ b/app/main.js
@@ -3,14 +3,6 @@ var childProcess = require("child_process");
 var path = require("path");
 var fs = require("fs");
 
-// var log = function(msg){
-//   fs.appendFile("C:\\Users\\Michael\\electron.log", msg + "\n", function(err){
-//     if (err){
-//       throw err;
-//     }
-//   })
-// };
-
 var log = function(){};
 
 var installShortcut = function(callback){
@@ -120,7 +112,10 @@ var windowOptions = {
     nodeIntegration: false,
     // See comments at the top of `preload.js`.
     preload: path.join(__dirname, 'preload.js')
-  }
+  },
+
+  experimentalFeatures: electronSettings.experimentalFeatures,
+  blinkFeatures: electronSettings.blinkFeatures,
 };
 
 if (electronSettings.resizable === false){
@@ -163,6 +158,7 @@ var getMainWindow = function() {
 createDefaultMenu(app, getMainWindow, checkForUpdates);
 
 app.on("ready", function(){
+  console.log(`ELECTRON VERSION: ${process.versions.electron}\nCHROME VERSION: ${process.versions.chrome}`);
   mainWindow = new BrowserWindow(windowOptions);
   proxyWindowEvents(mainWindow);
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,12 +1,11 @@
-var BrowserWindow = require('browser-window');
-var Menu = require('menu');
+const { BrowserWindow, Menu } = require('electron');
 
 /**
  * Creates a default menu. Modeled after https://github.com/atom/electron/pull/1863, augmented with
  * the roles from https://github.com/atom/electron/blob/master/docs/api/menu.md.
  */
-var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
-  app.once('ready', function() {
+var createDefaultMenu = function (app, getMainWindow, checkForUpdates) {
+  app.once('ready', function () {
     var template;
     if (process.platform == 'darwin') {
       template = [
@@ -18,39 +17,39 @@ var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
               role: 'about',
             },
             {
-              type: 'separator'
+              type: 'separator',
             },
             {
               label: 'Services',
               role: 'services',
-              submenu: []
+              submenu: [],
             },
             {
-              type: 'separator'
+              type: 'separator',
             },
             {
               label: 'Hide ' + app.getName(),
               accelerator: 'Command+H',
-              role: 'hide'
+              role: 'hide',
             },
             {
               label: 'Hide Others',
               accelerator: 'Command+Shift+H',
-              role: 'hideothers'
+              role: 'hideothers',
             },
             {
               label: 'Show All',
-              role: 'unhide'
+              role: 'unhide',
             },
             {
-              type: 'separator'
+              type: 'separator',
             },
             {
               label: 'Quit',
               accelerator: 'Command+Q',
-              click: function() { app.quit(); }
+              click: function () { app.quit(); },
             },
-          ]
+          ],
         },
         {
           label: 'File',
@@ -58,19 +57,19 @@ var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
             {
               label: 'Refresh',
               accelerator: 'Command+R',
-              click: function() {
+              click: function () {
                 var focusedWindow = BrowserWindow.getFocusedWindow();
                 if (focusedWindow) {
                   focusedWindow.reload();
                 }
-              }
+              },
             },
             {
               label: 'Close',
               accelerator: 'Command+W',
-              role: 'close'
-            }
-          ]
+              role: 'close',
+            },
+          ],
         },
         {
           label: 'Edit',
@@ -78,37 +77,37 @@ var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
             {
               label: 'Undo',
               accelerator: 'Command+Z',
-              role: 'undo'
+              role: 'undo',
             },
             {
               label: 'Redo',
               accelerator: 'Shift+Command+Z',
-              role: 'redo'
+              role: 'redo',
             },
             {
-              type: 'separator'
+              type: 'separator',
             },
             {
               label: 'Cut',
               accelerator: 'Command+X',
-              role: 'cut'
+              role: 'cut',
             },
             {
               label: 'Copy',
               accelerator: 'Command+C',
-              role: 'copy'
+              role: 'copy',
             },
             {
               label: 'Paste',
               accelerator: 'Command+V',
-              role: 'paste'
+              role: 'paste',
             },
             {
               label: 'Select All',
               accelerator: 'Command+A',
-              role: 'selectall'
+              role: 'selectall',
             },
-          ]
+          ],
         },
         {
           label: 'Window',
@@ -116,47 +115,47 @@ var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
             {
               label: 'Minimize',
               accelerator: 'Command+M',
-              role: 'minimize'
+              role: 'minimize',
             },
             {
               label: 'Toggle Full Screen',
               accelerator: 'Ctrl+Command+F',
-              click: function() {
+              click: function () {
                 var focusedWindow = BrowserWindow.getFocusedWindow();
                 if (focusedWindow) {
                   focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
                 }
-              }
+              },
             },
             {
-              type: 'separator'
+              type: 'separator',
             },
             {
               label: 'Main Window',
               accelerator: 'Command+1',
-              click: function() {
+              click: function () {
                 var mainWindow = getMainWindow();
                 if (mainWindow) {
                   mainWindow.show();
                 }
-              }
+              },
             },
             {
-              type: 'separator'
+              type: 'separator',
             },
             {
               label: 'Bring All to Front',
-              role: 'front'
+              role: 'front',
             },
-          ]
-        }
+          ],
+        },
       ];
 
       if (checkForUpdates) {
         // Add 'Check for Updates' below the 'About' menu item.
         template[0].submenu.splice(1, 0, {
           label: 'Check for Updates',
-          click: checkForUpdates
+          click: checkForUpdates,
         });
       }
     } else {
@@ -171,24 +170,24 @@ var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
             {
               label: '&Refresh',
               accelerator: 'Ctrl+R',
-              click: function() {
+              click: function () {
                 var focusedWindow = BrowserWindow.getFocusedWindow();
                 if (focusedWindow) {
                   focusedWindow.reload();
                 }
-              }
+              },
             },
             {
               label: '&Close',
               accelerator: 'Ctrl+W',
-              click: function() {
+              click: function () {
                 var focusedWindow = BrowserWindow.getFocusedWindow();
                 if (focusedWindow) {
                   focusedWindow.close();
                 }
-              }
+              },
             },
-          ]
+          ],
         },
         {
           label: '&Window',
@@ -196,24 +195,24 @@ var createDefaultMenu = function(app, getMainWindow, checkForUpdates) {
             {
               label: 'Toggle &Full Screen',
               accelerator: 'F11',
-              click: function() {
+              click: function () {
                 var focusedWindow = BrowserWindow.getFocusedWindow();
                 if (focusedWindow) {
                   focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
                 }
-              }
-            }
-          ]
-        }
+              },
+            },
+          ],
+        },
       ];
 
       if (checkForUpdates) {
         // Add a separator and 'Check for Updates' at the bottom of the 'File' menu.
         template[0].submenu.push({
-          type: 'separator'
+          type: 'separator',
         }, {
           label: '&Check for Updates',
-          click: checkForUpdates
+          click: checkForUpdates,
         });
       }
     }

--- a/package.js
+++ b/package.js
@@ -1,30 +1,30 @@
 /* global Package:false, Npm:false */
 
 Package.describe({
-  name: 'meson:electron',
-  summary: "Electron",
-  version: "0.1.4",
-  git: "https://github.com/electron-webapps/meteor-electron"
+  name: 'meson:electron-modified',
+  summary: 'Electron',
+  version: '0.1.4',
+  git: 'https://github.com/electron-webapps/meteor-electron',
 });
 
 Npm.depends({
-  "electron-packager": "https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz",
-  "is-running": "1.0.5",
-  "lucy-dirsum": "https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz",
-  "mkdirp": "0.5.1",
-  "ncp": "2.0.0",
-  "rimraf": "2.4.4",
-  "semver": "5.1.0",
-  "url-join": "0.0.1",
-  "electron-rebuild": "1.0.1"
+  'electron-packager': 'https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz',
+  'is-running': '1.0.5',
+  'lucy-dirsum': 'https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz',
+  mkdirp: '0.5.1',
+  ncp: '2.0.0',
+  rimraf: '2.4.4',
+  semver: '5.1.0',
+  'url-join': '0.0.1',
+  'electron-rebuild': '1.2.1',
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom("METEOR@1.0");
-  api.use(["mongo-livedata", "webapp", "ejson", "promise@0.6.7"], "server");
-  api.use("underscore", ["server", "client"]);
-  api.use(["iron:router@0.9.4||1.0.0"], {weak: true});
-  api.use("meteorhacks:picker@1.0.0", "server", {weak: true});
+  api.versionsFrom('METEOR@1.0');
+  api.use(['mongo-livedata', 'webapp', 'ejson', 'promise@0.6.7'], 'server');
+  api.use('underscore', ['server', 'client']);
+  api.use(['iron:router@0.9.4||1.0.0'], { weak: true });
+  api.use('meteorhacks:picker@1.0.0', 'server', { weak: true });
 
   api.addFiles([
     'server/createBinaries.js',
@@ -34,40 +34,40 @@ Package.onUse(function (api) {
     'server/serveDownloadUrl.js',
     'server/serveUpdateFeed.js',
     // Must go last so that its dependencies have been defined.
-    'server/index.js'
+    'server/index.js',
   ], 'server');
 
   var assets = [
-    "app/autoUpdater.js",
-    "app/main.js",
-    "app/menu.js",
-    "app/package.json",
-    "app/preload.js",
-    "app/proxyWindowEvents.js"
+    'app/autoUpdater.js',
+    'app/main.js',
+    'app/menu.js',
+    'app/package.json',
+    'app/preload.js',
+    'app/proxyWindowEvents.js',
   ];
 
   // Use Meteor 1.2+ API, but fall back to the pre-1.2 API if necessary
   if (api.addAssets) {
-    api.addAssets(assets, "server");
+    api.addAssets(assets, 'server');
   } else {
-    api.addFiles(assets, "server", {isAsset: true});
+    api.addFiles(assets, 'server', { isAsset: true });
   }
 
-  api.addFiles(['client/index.js'], "client");
+  api.addFiles(['client/index.js'], 'client');
 
   // Test exports.
   api.export([
     'parseMacDownloadUrl',
-    'parseWindowsDownloadUrls'
+    'parseWindowsDownloadUrls',
   ], 'server', {
-    testOnly: true
+    testOnly: true,
   });
 
   // Public exports.
-  api.export("Electron", ["client"]);
+  api.export('Electron', ['client']);
 });
 
-Package.onTest(function(api) {
+Package.onTest(function (api) {
   api.use(['meson:electron', 'tinytest']);
 
   api.addFiles('tests/server/downloadUrlsTest.js', 'server');


### PR DESCRIPTION
first of all, awesome package!

I was using for my app, and wanted to have the final build automatically build not just to .meteor-electron but also a local repo -- like /public or /private so I could serve on the site right away without doing anything manual.

So this change simply looks to see if downloadUrl is a local path -- not http -- and if so runs the same code to compress and send to /final to also send into the local dir. Right now only works with darwin as I still haven't messed with win32.

Feel free to modify or reject, but I thought it was worth starting the conversation.

Cheers,
Simon
