### PR TITLE
Implement full IPC API on render process

### DIFF
--- a/app/preload.js
+++ b/app/preload.js
@@ -67,19 +67,29 @@ ElectronImplementation = {
    * Invokes _callback_ when the specified IPC event is fired.
    *
    * @param {String} event - The name of an event.
-   * @param {Function} callback - A function to invoke when `event` is triggered. Takes no arguments
-   *   and returns no value.
+   * @param {Function} callback - A function to invoke when `event` is triggered. Called with
+   *   the signature (event, ...args) - see http://electron.atom.io/docs/v0.37.2/api/ipc-renderer/#sending-messages
    */
   onEvent: function(event, callback) {
     var listeners = this._eventListeners[event];
     if (!listeners) {
       listeners = this._eventListeners[event] = [];
-      ipc.on(event, function() {
-        _.invoke(listeners, 'call');
+      ipc.on(event, function(/* event, ...args */) {
+        _.invoke(listeners, 'apply', null, arguments);
       });
     }
     listeners.push(callback);
   },
 
-  _eventListeners: {}
+  _eventListeners: {},
+
+  /**
+   * Send an event to the main Electron process.
+   *
+   * @param {String} event - The name of an event.
+   * @param {...*} arg - additional arguments to pass to event handler.
+   */
+  sendIpcEvent: function(/* event , ...args */) {
+    ipc.send.apply(null, arguments);
+  },
 };

--- a/app/preload.js
+++ b/app/preload.js
@@ -89,7 +89,7 @@ ElectronImplementation = {
    * @param {String} event - The name of an event.
    * @param {...*} arg - additional arguments to pass to event handler.
    */
-  sendIpcEvent: function(/* event , ...args */) {
+  send: function(/* event , ...args */) {
     ipc.send.apply(null, arguments);
   },
 };


### PR DESCRIPTION
For the app I'm working on, I'd like to be able to communicate arbitrary messages between the main and render processes. It requires a tray, etc., so I'm using a fork of the `app/` directory in `private/` as recommended in the readme. I think the best way for the main and render processes to communicate is via messages, in the direction suggested in #58, rather than to expose functions directly. 

IPC is present in Electron for this purpose, but the full API is currently limited on the render process by `meson:electron`. `Electron.onEvent()` allows the render process to receive an IPC message from main, but it does not pass through the event object or any additional parameters you may want to send. Also, there is no way to signal up to the main process. 

The code in this PR proposes changing `Electron.onEvent()` to provide the full IPC API as documented [here](http://electron.atom.io/docs/v0.37.2/api/web-contents/#webcontentssendchannel-arg1-arg2-) and adding  `Electron.sendIpcEvent()` for communication from render process to main. I'm not attached to the exact method names. In fact, it might make sense to name them closer to the Electron API: `Electron.ipcRendererOn()` and `Electron.ipcRendererSend()` or similar so that new users can relate it to the Electron docs more readily.

These changes make it possible to safely provide any functionality needed. It might make sense to add a method/RPC type of abstraction on top of this where you could provide something like `Electron.call('setTrayIcon', 'alert')` or `Electron.call('promptUser', choices)` which could return a promise or otherwise help with async responses. This would feel natural to Meteor devs and wouldn't add much code to `meson:electron`.
