### PR TITLE
Bundling meteor client for offline use.

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,31 +1,90 @@
 {
   "dependencies": {
     "electron-packager": {
-      "version": "https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz",
+      "version": "5.1.1",
+      "resolved": "https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz",
+      "from": "https://github.com/mixmaxhq/electron-packager/archive/f511e2680efa39c014d8bedca872168e585f8daf.tar.gz",
       "dependencies": {
         "asar": {
           "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/asar/-/asar-0.8.3.tgz",
+          "from": "https://registry.npmjs.org/asar/-/asar-0.8.3.tgz",
           "dependencies": {
             "chromium-pickle-js": {
-              "version": "0.1.0"
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
+              "from": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz"
             },
             "commander": {
-              "version": "2.3.0"
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
             },
             "cuint": {
-              "version": "0.1.5"
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.1.5.tgz",
+              "from": "https://registry.npmjs.org/cuint/-/cuint-0.1.5.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
             },
             "minimatch": {
               "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0"
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
-                      "version": "0.0.1"
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
                 }
@@ -33,68 +92,106 @@
             },
             "mksnapshot": {
               "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
+              "from": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
               "dependencies": {
                 "decompress-zip": {
                   "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+                  "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
                   "dependencies": {
                     "binary": {
                       "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+                      "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                       "dependencies": {
+                        "buffers": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                          "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                        },
                         "chainsaw": {
                           "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                          "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                           "dependencies": {
                             "traverse": {
-                              "version": "0.3.9"
+                              "version": "0.3.9",
+                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                              "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                             }
                           }
-                        },
-                        "buffers": {
-                          "version": "0.1.1"
                         }
                       }
                     },
                     "graceful-fs": {
-                      "version": "3.0.8"
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "mkpath": {
-                      "version": "0.1.0"
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+                      "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                     },
                     "nopt": {
                       "version": "3.0.6",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                      "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                       "dependencies": {
                         "abbrev": {
-                          "version": "1.0.7"
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                         }
                       }
                     },
                     "q": {
-                      "version": "1.4.1"
+                      "version": "1.4.1",
+                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                      "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.1"
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
                     "touch": {
                       "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+                      "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
                       "dependencies": {
                         "nopt": {
                           "version": "1.0.10",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                           "dependencies": {
                             "abbrev": {
-                              "version": "1.0.7"
+                              "version": "1.0.7",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                             }
                           }
                         }
@@ -104,224 +201,304 @@
                 },
                 "fs-extra": {
                   "version": "0.18.2",
+                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+                  "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "3.0.8"
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "jsonfile": {
-                      "version": "2.2.3"
+                      "version": "2.2.3",
+                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+                      "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
                     }
                   }
                 },
                 "request": {
                   "version": "2.55.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+                  "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
                   "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
                     "bl": {
                       "version": "0.9.4",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
+                          "from": "readable-stream@1.0.33",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
-                              "version": "2.0.1"
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
                         }
                       }
                     },
                     "caseless": {
-                      "version": "0.9.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "0.2.0",
-                      "dependencies": {
-                        "async": {
-                          "version": "0.9.2"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "mime-types": {
-                      "version": "2.0.14",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.12.0"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "qs": {
-                      "version": "2.4.2"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.1"
-                    },
-                    "http-signature": {
-                      "version": "0.10.1",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5"
-                        },
-                        "asn1": {
-                          "version": "0.1.11"
-                        },
-                        "ctype": {
-                          "version": "0.5.3"
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.6.0"
-                    },
-                    "hawk": {
-                      "version": "2.3.1",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "boom": {
-                          "version": "2.10.1"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.5.0"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
+                      "version": "0.9.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+                      "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
-                          "version": "0.0.5"
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
-                    "isstream": {
-                      "version": "0.1.2"
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.2",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                        }
+                      }
                     },
                     "har-validator": {
                       "version": "1.8.0",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+                      "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                       "dependencies": {
                         "bluebird": {
-                          "version": "2.10.2"
+                          "version": "2.10.2",
+                          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+                          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
                         },
                         "chalk": {
                           "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
-                              "version": "2.1.0"
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
-                              "version": "1.0.3"
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
-                                  "version": "2.0.0"
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
-                                  "version": "2.0.0"
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "commander": {
                           "version": "2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "dependencies": {
                             "graceful-readlink": {
-                              "version": "1.0.1"
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                             }
                           }
                         },
                         "is-my-json-valid": {
                           "version": "2.12.3",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
                           "dependencies": {
                             "generate-function": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                             },
                             "generate-object-property": {
                               "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                               "dependencies": {
                                 "is-property": {
-                                  "version": "1.0.2"
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                 }
                               }
                             },
                             "jsonpointer": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                             },
                             "xtend": {
-                              "version": "4.0.1"
+                              "version": "4.0.1",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                             }
                           }
                         }
                       }
+                    },
+                    "hawk": {
+                      "version": "2.3.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                      "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.10.1",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                          "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                          "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.14",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.12.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+                      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                    },
+                    "qs": {
+                      "version": "2.4.2",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+                      "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+                      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                     }
                   }
-                }
-              }
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
                 }
               }
             }
@@ -329,82 +506,127 @@
         },
         "electron-download": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-1.4.1.tgz",
+          "from": "https://registry.npmjs.org/electron-download/-/electron-download-1.4.1.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
+              "from": "debug@2.2.0",
               "dependencies": {
                 "ms": {
-                  "version": "0.7.1"
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "home-path": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.1.tgz",
+              "from": "https://registry.npmjs.org/home-path/-/home-path-1.0.1.tgz"
             },
             "nugget": {
               "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.0.tgz",
+              "from": "https://registry.npmjs.org/nugget/-/nugget-1.6.0.tgz",
               "dependencies": {
                 "pretty-bytes": {
                   "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+                  "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
                   "dependencies": {
                     "get-stdin": {
-                      "version": "4.0.1"
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "meow": {
                       "version": "3.6.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                      "from": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.0.1"
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
                             },
                             "map-obj": {
-                              "version": "1.0.1"
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                             }
                           }
                         },
                         "loud-rejection": {
                           "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                          "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                           "dependencies": {
                             "signal-exit": {
-                              "version": "2.1.2"
+                              "version": "2.1.2",
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                              "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                             }
                           }
                         },
                         "normalize-package-data": {
                           "version": "2.3.5",
+                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                          "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "dependencies": {
                             "hosted-git-info": {
-                              "version": "2.1.4"
+                              "version": "2.1.4",
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                              "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                             },
                             "is-builtin-module": {
                               "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "dependencies": {
                                 "builtin-modules": {
-                                  "version": "1.1.0"
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                                  "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                                 }
                               }
                             },
                             "validate-npm-package-license": {
                               "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "dependencies": {
                                 "spdx-correct": {
                                   "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-license-ids": {
-                                      "version": "1.1.0"
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                                      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                     }
                                   }
                                 },
                                 "spdx-expression-parse": {
                                   "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                                  "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-exceptions": {
-                                      "version": "1.0.4"
+                                      "version": "1.0.4",
+                                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                                      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                     },
                                     "spdx-license-ids": {
-                                      "version": "1.1.0"
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                                      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                     }
                                   }
                                 }
@@ -413,22 +635,34 @@
                           }
                         },
                         "object-assign": {
-                          "version": "4.0.1"
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                         },
                         "read-pkg-up": {
                           "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                          "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "dependencies": {
                             "find-up": {
                               "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                               "dependencies": {
                                 "path-exists": {
-                                  "version": "2.1.0"
+                                  "version": "2.1.0",
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
-                                      "version": "2.0.1"
+                                      "version": "2.0.1",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                     }
                                   }
                                 }
@@ -436,42 +670,64 @@
                             },
                             "read-pkg": {
                               "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                              "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                               "dependencies": {
                                 "load-json-file": {
                                   "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                                  "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
-                                      "version": "4.1.2"
+                                      "version": "4.1.2",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                     },
                                     "parse-json": {
                                       "version": "2.2.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                       "dependencies": {
                                         "error-ex": {
                                           "version": "1.3.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                          "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                           "dependencies": {
                                             "is-arrayish": {
-                                              "version": "0.2.1"
+                                              "version": "0.2.1",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                              "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                             }
                                           }
                                         }
                                       }
                                     },
                                     "pify": {
-                                      "version": "2.3.0"
+                                      "version": "2.3.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "dependencies": {
                                         "pinkie": {
-                                          "version": "2.0.1"
+                                          "version": "2.0.1",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                         }
                                       }
                                     },
                                     "strip-bom": {
                                       "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                       "dependencies": {
                                         "is-utf8": {
-                                          "version": "0.2.0"
+                                          "version": "0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                         }
                                       }
                                     }
@@ -479,18 +735,28 @@
                                 },
                                 "path-type": {
                                   "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                                  "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
-                                      "version": "4.1.2"
+                                      "version": "4.1.2",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                     },
                                     "pify": {
-                                      "version": "2.3.0"
+                                      "version": "2.3.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "dependencies": {
                                         "pinkie": {
-                                          "version": "2.0.1"
+                                          "version": "2.0.1",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                         }
                                       }
                                     }
@@ -502,18 +768,28 @@
                         },
                         "redent": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                          "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                           "dependencies": {
                             "indent-string": {
                               "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "dependencies": {
                                 "repeating": {
                                   "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "dependencies": {
                                         "number-is-nan": {
-                                          "version": "1.0.0"
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                         }
                                       }
                                     }
@@ -522,12 +798,16 @@
                               }
                             },
                             "strip-indent": {
-                              "version": "1.0.1"
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                              "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                             }
                           }
                         },
                         "trim-newlines": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                          "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                         }
                       }
                     }
@@ -535,303 +815,471 @@
                 },
                 "progress-stream": {
                   "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+                  "from": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
                   "dependencies": {
+                    "speedometer": {
+                      "version": "0.1.4",
+                      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+                      "from": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz"
+                    },
                     "through2": {
                       "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+                      "from": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.13",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
-                              "version": "2.0.1"
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
                         },
                         "xtend": {
                           "version": "2.1.2",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                           "dependencies": {
                             "object-keys": {
-                              "version": "0.4.0"
+                              "version": "0.4.0",
+                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                              "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                             }
                           }
                         }
                       }
-                    },
-                    "speedometer": {
-                      "version": "0.1.4"
                     }
                   }
                 },
                 "request": {
                   "version": "2.67.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+                  "from": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
                   "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
                     "bl": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.2"
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
-                              "version": "2.0.1"
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "isarray": {
-                              "version": "0.0.1"
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "process-nextick-args": {
-                              "version": "1.0.6"
+                              "version": "1.0.6",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                             },
                             "string_decoder": {
-                              "version": "0.10.31"
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "util-deprecate": {
-                              "version": "1.0.2"
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
                         }
                       }
                     },
                     "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "dependencies": {
-                        "async": {
-                          "version": "1.5.0"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "mime-types": {
-                      "version": "2.1.8",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.20.0"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "qs": {
-                      "version": "5.2.0"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.1"
-                    },
-                    "http-signature": {
-                      "version": "1.1.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5"
-                        },
-                        "jsprim": {
-                          "version": "1.2.2",
-                          "dependencies": {
-                            "extsprintf": {
-                              "version": "1.0.2"
-                            },
-                            "json-schema": {
-                              "version": "0.2.2"
-                            },
-                            "verror": {
-                              "version": "1.3.6"
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.7.1",
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3"
-                            },
-                            "assert-plus": {
-                              "version": "0.2.0"
-                            },
-                            "dashdash": {
-                              "version": "1.10.1",
-                              "dependencies": {
-                                "assert-plus": {
-                                  "version": "0.1.5"
-                                }
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.0"
-                            },
-                            "tweetnacl": {
-                              "version": "0.13.2"
-                            },
-                            "jodid25519": {
-                              "version": "1.0.2"
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.0"
-                    },
-                    "hawk": {
-                      "version": "3.1.2",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "boom": {
-                          "version": "2.10.1"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
+                      "version": "0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                      "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                       "dependencies": {
                         "delayed-stream": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                         }
                       }
                     },
-                    "isstream": {
-                      "version": "0.1.2"
+                    "extend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                      "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                     },
-                    "is-typedarray": {
-                      "version": "1.0.0"
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "1.5.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                          "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                        }
+                      }
                     },
                     "har-validator": {
                       "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
+                      "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                           "dependencies": {
                             "ansi-styles": {
-                              "version": "2.1.0"
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                             },
                             "escape-string-regexp": {
-                              "version": "1.0.3"
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
-                                  "version": "2.0.0"
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
-                                  "version": "2.0.0"
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "commander": {
                           "version": "2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "dependencies": {
                             "graceful-readlink": {
-                              "version": "1.0.1"
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                             }
                           }
                         },
                         "is-my-json-valid": {
                           "version": "2.12.3",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
                           "dependencies": {
                             "generate-function": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                             },
                             "generate-object-property": {
                               "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                               "dependencies": {
                                 "is-property": {
-                                  "version": "1.0.2"
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                 }
                               }
                             },
                             "jsonpointer": {
-                              "version": "2.0.0"
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                             },
                             "xtend": {
-                              "version": "4.0.1"
+                              "version": "4.0.1",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                             }
                           }
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
-                              "version": "2.0.1"
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                             }
                           }
                         }
                       }
+                    },
+                    "hawk": {
+                      "version": "3.1.2",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+                      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.10.1",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                          "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                          "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+                      "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "jsprim": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                          "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                          "dependencies": {
+                            "extsprintf": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                              "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                            },
+                            "json-schema": {
+                              "version": "0.2.2",
+                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                              "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                            },
+                            "verror": {
+                              "version": "1.3.6",
+                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                              "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.7.1",
+                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                          "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                              "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                            },
+                            "assert-plus": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                            },
+                            "dashdash": {
+                              "version": "1.10.1",
+                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                              "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.5",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                }
+                              }
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                              "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                            },
+                            "jodid25519": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                              "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                            },
+                            "jsbn": {
+                              "version": "0.1.0",
+                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                              "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                            },
+                            "tweetnacl": {
+                              "version": "0.13.2",
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
+                              "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                      "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.8",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.20.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                      "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+                      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                     }
                   }
                 },
                 "single-line-log": {
-                  "version": "0.4.1"
+                  "version": "0.4.1",
+                  "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
+                  "from": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz"
                 },
                 "throttleit": {
-                  "version": "0.0.2"
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+                  "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
             },
             "path-exists": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+              "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
             },
             "rc": {
               "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+              "from": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
               "dependencies": {
                 "deep-extend": {
-                  "version": "0.4.0"
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz",
+                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
                 },
                 "ini": {
-                  "version": "1.3.4"
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "strip-json-comments": {
-                  "version": "1.0.4"
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 }
               }
             }
@@ -839,167 +1287,266 @@
         },
         "extract-zip": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.3.0.tgz",
+          "from": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.3.0.tgz",
           "dependencies": {
             "async": {
-              "version": "1.5.0"
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+              "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
             },
             "concat-stream": {
               "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1"
-                },
-                "typedarray": {
-                  "version": "0.0.6"
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1"
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6"
+                      "version": "1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
-                      "version": "0.10.31"
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2"
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
             "debug": {
-              "version": "0.7.4"
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "mkdirp": {
               "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8"
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "yauzl": {
               "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+              "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
               "dependencies": {
                 "fd-slicer": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                  "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
                 },
                 "pend": {
-                  "version": "1.2.0"
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                  "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
                 }
               }
             }
           }
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "mv": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+          "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz"
         },
         "plist": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+          "from": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
           "dependencies": {
             "base64-js": {
-              "version": "0.0.8"
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             },
             "xmlbuilder": {
               "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.10.1"
+                  "version": "3.10.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "xmldom": {
-              "version": "0.1.19"
-            },
-            "util-deprecate": {
-              "version": "1.0.2"
+              "version": "0.1.19",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+              "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
             }
           }
         },
         "rcedit": {
-          "version": "0.3.0"
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.3.0.tgz",
+          "from": "https://registry.npmjs.org/rcedit/-/rcedit-0.3.0.tgz"
         },
         "run-series": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
+          "from": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
         }
       }
     },
     "electron-rebuild": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.0.1.tgz",
+      "from": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.0.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "5.8.35",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
           "dependencies": {
             "core-js": {
-              "version": "1.2.6"
+              "version": "1.2.6",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
         },
         "lodash": {
-          "version": "3.10.1"
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "npm": {
           "version": "2.14.18",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.14.18.tgz",
+          "from": "https://registry.npmjs.org/npm/-/npm-2.14.18.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.7"
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.7 <1.1.0"
             },
             "ansi": {
-              "version": "0.3.1"
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+              "from": "ansi@latest"
+            },
+            "ansi-regex": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "from": "ansi-regex@2.0.0"
             },
             "ansicolors": {
-              "version": "0.3.2"
+              "version": "0.3.2",
+              "from": "ansicolors@latest"
             },
             "ansistyles": {
-              "version": "0.1.3"
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+              "from": "ansistyles@0.1.3"
             },
             "archy": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "from": "archy@>=1.0.0 <2.0.0"
             },
             "async-some": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "async-some@>=1.0.2 <1.1.0"
             },
             "block-stream": {
-              "version": "0.0.8"
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+              "from": "block-stream@0.0.8"
             },
             "char-spinner": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+              "from": "char-spinner@latest"
             },
             "chmodr": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+              "from": "chmodr@>=1.0.2 <1.1.0"
             },
             "chownr": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "from": "chownr@1.0.1"
             },
             "cmd-shim": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.1.tgz",
+              "from": "cmd-shim@>=2.0.1-0 <3.0.0-0",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "3.0.8"
+                  "version": "3.0.8",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                  "from": "graceful-fs@>3.0.1 <4.0.0-0"
                 }
               }
             },
             "columnify": {
               "version": "1.5.4",
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+              "from": "columnify@latest",
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+                  "from": "wcwidth@>=1.0.0 <2.0.0",
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                      "from": "defaults@>=1.0.0 <2.0.0",
                       "dependencies": {
                         "clone": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                          "from": "clone@>=1.0.2 <2.0.0"
                         }
                       }
                     }
@@ -1009,112 +1556,173 @@
             },
             "config-chain": {
               "version": "1.1.10",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+              "from": "config-chain@latest",
               "dependencies": {
                 "proto-list": {
-                  "version": "1.2.4"
+                  "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "from": "proto-list@>=1.2.1 <1.3.0"
                 }
               }
             },
             "dezalgo": {
               "version": "1.0.3",
+              "from": "dezalgo@>=1.0.3 <1.1.0",
               "dependencies": {
                 "asap": {
-                  "version": "2.0.3"
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
+                  "from": "asap@>=2.0.0 <3.0.0"
                 }
               }
             },
             "editor": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+              "from": "editor@>=1.0.0 <1.1.0"
             },
             "fs-vacuum": {
-              "version": "1.2.7"
+              "version": "1.2.7",
+              "from": "fs-vacuum@1.2.7"
             },
             "fs-write-stream-atomic": {
               "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
+              "from": "fs-write-stream-atomic@>=1.0.5 <1.1.0",
               "dependencies": {
                 "iferr": {
-                  "version": "0.1.5"
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+                  "from": "iferr@>=0.1.5 <0.2.0"
                 }
               }
             },
             "fstream": {
-              "version": "1.0.8"
+              "version": "1.0.8",
+              "from": "fstream@1.0.8"
             },
             "fstream-npm": {
               "version": "1.0.7",
+              "from": "fstream-npm@>=1.0.7 <1.1.0",
               "dependencies": {
                 "fstream-ignore": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                  "from": "fstream-ignore@>=1.0.0 <2.0.0"
                 }
               }
             },
             "github-url-from-git": {
-              "version": "1.4.0"
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+              "from": "github-url-from-git@>=1.4.0-0 <2.0.0-0"
             },
             "github-url-from-username-repo": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0"
             },
             "glob": {
               "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "from": "glob@5.0.15",
               "dependencies": {
                 "path-is-absolute": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
                 }
               }
             },
             "graceful-fs": {
-              "version": "4.1.3"
+              "version": "4.1.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+              "from": "graceful-fs@latest"
             },
             "hosted-git-info": {
-              "version": "2.1.4"
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+              "from": "hosted-git-info@>=2.1.2 <2.2.0"
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "from": "imurmurhash@0.1.4"
             },
             "inflight": {
-              "version": "1.0.4"
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <1.1.0"
             },
             "inherits": {
-              "version": "2.0.1"
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@latest"
             },
             "ini": {
-              "version": "1.3.4"
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "from": "ini@latest"
             },
             "init-package-json": {
               "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.3.tgz",
+              "from": "init-package-json@1.9.3",
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "from": "glob@>=6.0.0 <7.0.0",
                   "dependencies": {
                     "path-is-absolute": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0"
                     }
                   }
                 },
                 "promzard": {
-                  "version": "0.3.0"
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+                  "from": "promzard@>=0.3.0 <0.4.0"
                 }
               }
             },
             "lockfile": {
-              "version": "1.0.1"
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+              "from": "lockfile@>=1.0.0 <1.1.0"
             },
             "lru-cache": {
               "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+              "from": "lru-cache@>=3.2.0 <3.3.0",
               "dependencies": {
                 "pseudomap": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.1.tgz",
+                  "from": "pseudomap@>=1.0.1 <2.0.0"
                 }
               }
             },
             "minimatch": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "from": "minimatch@>=3.0.0 <3.1.0",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.1"
+                      "version": "0.2.1",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1"
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1"
                     }
                   }
                 }
@@ -1122,29 +1730,45 @@
             },
             "mkdirp": {
               "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8"
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8"
                 }
               }
             },
             "node-gyp": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
+              "from": "node-gyp@>=3.2.1 <3.3.0",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0"
+                              "version": "0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "from": "balanced-match@>=0.3.0 <0.4.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1"
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1"
                             }
                           }
                         }
@@ -1154,43 +1778,67 @@
                 },
                 "minimatch": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.3"
+                      "version": "2.7.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0"
                     },
                     "sigmund": {
-                      "version": "1.0.1"
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
                     }
                   }
                 },
                 "npmlog": {
                   "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
                   "dependencies": {
                     "are-we-there-yet": {
                       "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                       "dependencies": {
                         "delegates": {
-                          "version": "0.1.0"
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                          "from": "delegates@>=0.1.0 <0.2.0"
                         }
                       }
                     },
                     "gauge": {
                       "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "from": "gauge@>=1.2.0 <1.3.0",
                       "dependencies": {
                         "has-unicode": {
-                          "version": "1.0.1"
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+                          "from": "has-unicode@>=1.0.0 <2.0.0"
                         },
                         "lodash.pad": {
                           "version": "3.1.1",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "from": "lodash.pad@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash._basetostring": {
-                              "version": "3.0.1"
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "dependencies": {
                                 "lodash.repeat": {
-                                  "version": "3.0.1"
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
                                 }
                               }
                             }
@@ -1198,15 +1846,23 @@
                         },
                         "lodash.padleft": {
                           "version": "3.1.1",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash._basetostring": {
-                              "version": "3.0.1"
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "dependencies": {
                                 "lodash.repeat": {
-                                  "version": "3.0.1"
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
                                 }
                               }
                             }
@@ -1214,15 +1870,23 @@
                         },
                         "lodash.padright": {
                           "version": "3.1.1",
+                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "from": "lodash.padright@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash._basetostring": {
-                              "version": "3.0.1"
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "dependencies": {
                                 "lodash.repeat": {
-                                  "version": "3.0.1"
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
                                 }
                               }
                             }
@@ -1234,15 +1898,23 @@
                 },
                 "path-array": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
+                  "from": "path-array@>=1.0.0 <2.0.0",
                   "dependencies": {
                     "array-index": {
                       "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
+                      "from": "array-index@>=0.1.0 <0.2.0",
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "from": "debug@*",
                           "dependencies": {
                             "ms": {
-                              "version": "0.7.1"
+                              "version": "0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "from": "ms@0.7.1"
                             }
                           }
                         }
@@ -1253,58 +1925,88 @@
               }
             },
             "nopt": {
-              "version": "3.0.6"
+              "version": "3.0.6",
+              "from": "nopt@>=3.0.6 <3.1.0"
             },
             "normalize-git-url": {
-              "version": "3.0.1"
+              "version": "3.0.1",
+              "from": "normalize-git-url@latest"
             },
             "normalize-package-data": {
               "version": "2.3.5",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "from": "normalize-package-data@>=2.3.5 <2.4.0",
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
                   "dependencies": {
                     "builtin-modules": {
-                      "version": "1.1.0"
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                      "from": "builtin-modules@>=1.0.0 <2.0.0"
                     }
                   }
                 }
               }
             },
             "npm-cache-filename": {
-              "version": "1.0.2"
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+              "from": "npm-cache-filename@1.0.2"
             },
             "npm-install-checks": {
               "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.6.tgz",
+              "from": "npm-install-checks@1.0.6",
               "dependencies": {
                 "npmlog": {
                   "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "from": "npmlog@>=0.1.0 <0.2.0||>=1.0.0 <2.0.0",
                   "dependencies": {
                     "are-we-there-yet": {
                       "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                       "dependencies": {
                         "delegates": {
-                          "version": "0.1.0"
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                          "from": "delegates@>=0.1.0 <0.2.0"
                         }
                       }
                     },
                     "gauge": {
                       "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "from": "gauge@>=1.2.0 <1.3.0",
                       "dependencies": {
                         "has-unicode": {
-                          "version": "1.0.1"
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz",
+                          "from": "has-unicode@>=1.0.0 <2.0.0"
                         },
                         "lodash.pad": {
                           "version": "3.1.1",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "from": "lodash.pad@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash._basetostring": {
-                              "version": "3.0.1"
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "dependencies": {
                                 "lodash.repeat": {
-                                  "version": "3.0.1"
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
                                 }
                               }
                             }
@@ -1312,15 +2014,23 @@
                         },
                         "lodash.padleft": {
                           "version": "3.1.1",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash._basetostring": {
-                              "version": "3.0.1"
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "dependencies": {
                                 "lodash.repeat": {
-                                  "version": "3.0.1"
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
                                 }
                               }
                             }
@@ -1328,15 +2038,23 @@
                         },
                         "lodash.padright": {
                           "version": "3.1.1",
+                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "from": "lodash.padright@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash._basetostring": {
-                              "version": "3.0.1"
+                              "version": "3.0.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                             },
                             "lodash._createpadding": {
                               "version": "3.6.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                               "dependencies": {
                                 "lodash.repeat": {
-                                  "version": "3.0.1"
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0"
                                 }
                               }
                             }
@@ -1349,83 +2067,129 @@
               }
             },
             "npm-package-arg": {
-              "version": "4.1.0"
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
+              "from": "npm-package-arg@>=4.1.0 <4.2.0"
             },
             "npm-registry-client": {
               "version": "7.0.9",
+              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.0.9.tgz",
+              "from": "npm-registry-client@>=7.0.9 <7.1.0",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
                   "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6"
-                    },
                     "readable-stream": {
                       "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
                         },
                         "isarray": {
-                          "version": "0.0.1"
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6"
+                          "version": "1.0.6",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0"
                         },
                         "string_decoder": {
-                          "version": "0.10.31"
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2"
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0"
                         }
                       }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "from": "typedarray@>=0.0.5 <0.1.0"
                     }
                   }
                 },
                 "retry": {
-                  "version": "0.8.0"
+                  "version": "0.8.0",
+                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz",
+                  "from": "retry@>=0.8.0 <0.9.0"
                 }
               }
             },
             "npm-user-validate": {
-              "version": "0.1.2"
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz",
+              "from": "npm-user-validate@>=0.1.1 <0.2.0"
             },
             "npmlog": {
               "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz",
+              "from": "npmlog@2.0.2",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+                  "from": "are-we-there-yet@>=1.0.6 <1.1.0",
                   "dependencies": {
                     "delegates": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "from": "delegates@>=1.0.0 <2.0.0"
                     }
                   }
                 },
                 "gauge": {
                   "version": "1.2.5",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz",
+                  "from": "gauge@>=1.2.5 <1.3.0",
                   "dependencies": {
                     "has-unicode": {
-                      "version": "2.0.0"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
+                      "from": "has-unicode@>=2.0.0 <3.0.0"
                     },
                     "lodash.pad": {
                       "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.2.2.tgz",
+                      "from": "lodash.pad@>=3.0.0 <4.0.0",
                       "dependencies": {
                         "lodash.repeat": {
-                          "version": "3.1.2"
+                          "version": "3.1.2",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz",
+                          "from": "lodash.repeat@>=3.0.0 <4.0.0"
                         }
                       }
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                      "from": "lodash.padleft@>=3.0.0 <4.0.0",
                       "dependencies": {
                         "lodash._basetostring": {
-                          "version": "3.0.1"
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash.repeat": {
-                              "version": "3.1.2"
+                              "version": "3.1.2",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0"
                             }
                           }
                         }
@@ -1433,592 +2197,27 @@
                     },
                     "lodash.padright": {
                       "version": "3.1.1",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                      "from": "lodash.padright@>=3.0.0 <4.0.0",
                       "dependencies": {
                         "lodash._basetostring": {
-                          "version": "3.0.1"
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0"
                         },
                         "lodash._createpadding": {
                           "version": "3.6.1",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
                           "dependencies": {
                             "lodash.repeat": {
-                              "version": "3.1.2"
+                              "version": "3.1.2",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.1.2.tgz",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0"
                             }
                           }
                         }
                       }
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3"
-            },
-            "opener": {
-              "version": "1.4.1"
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.0"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.1"
-            },
-            "read": {
-              "version": "1.0.7",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "dependencies": {
-                "debuglog": {
-                  "version": "1.0.1"
-                },
-                "readdir-scoped-modules": {
-                  "version": "1.0.2"
-                },
-                "util-extend": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.3",
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "json-parse-helpfulerror": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "jju": {
-                      "version": "1.2.1"
-                    }
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                }
-              }
-            },
-            "realize-package-specifier": {
-              "version": "3.0.1"
-            },
-            "request": {
-              "version": "2.69.0",
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "aws4": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3"
-                    }
-                  }
-                },
-                "bl": {
-                  "version": "1.0.2",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.5",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.11.0"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0"
-                },
-                "forever-agent": {
-                  "version": "0.6.1"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.2"
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.1.0"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.4"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0"
-                        },
-                        "supports-color": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.12.4",
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0"
-                        },
-                        "xtend": {
-                          "version": "4.0.1"
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2"
-                        },
-                        "json-schema": {
-                          "version": "0.2.2"
-                        },
-                        "verror": {
-                          "version": "1.3.6"
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.7.3",
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3"
-                        },
-                        "dashdash": {
-                          "version": "1.12.2"
-                        },
-                        "jsbn": {
-                          "version": "0.1.0"
-                        },
-                        "tweetnacl": {
-                          "version": "0.13.3"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0"
-                },
-                "isstream": {
-                  "version": "0.1.2"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "mime-types": {
-                  "version": "2.1.9",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.21.0"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7"
-                },
-                "oauth-sign": {
-                  "version": "0.8.1"
-                },
-                "qs": {
-                  "version": "6.0.2"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "tough-cookie": {
-                  "version": "2.2.1"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2"
-                }
-              }
-            },
-            "retry": {
-              "version": "0.9.0"
-            },
-            "rimraf": {
-              "version": "2.5.1",
-              "dependencies": {
-                "glob": {
-                  "version": "6.0.4",
-                  "dependencies": {
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.1.0"
-            },
-            "sha": {
-              "version": "2.0.1",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.2",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "slide": {
-              "version": "1.1.6"
-            },
-            "sorted-object": {
-              "version": "1.0.0"
-            },
-            "spdx-license-ids": {
-              "version": "1.2.0"
-            },
-            "tar": {
-              "version": "2.2.1"
-            },
-            "text-table": {
-              "version": "0.2.0"
-            },
-            "uid-number": {
-              "version": "0.0.6"
-            },
-            "umask": {
-              "version": "1.1.0"
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "dependencies": {
-                "spdx-correct": {
-                  "version": "1.0.2"
-                },
-                "spdx-expression-parse": {
-                  "version": "1.0.2",
-                  "dependencies": {
-                    "spdx-exceptions": {
-                      "version": "1.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "2.2.2",
-              "dependencies": {
-                "builtins": {
-                  "version": "0.0.7"
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.4",
-              "dependencies": {
-                "is-absolute": {
-                  "version": "0.1.7",
-                  "dependencies": {
-                    "is-relative": {
-                      "version": "0.1.3"
-                    }
-                  }
-                },
-                "isexe": {
-                  "version": "1.1.1"
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.1"
-            },
-            "write-file-atomic": {
-              "version": "1.1.4"
-            },
-            "ansi-regex": {
-              "version": "2.0.0"
-            },
-            "imurmurhash": {
-              "version": "0.1.4"
-            },
-            "strip-ansi": {
-              "version": "3.0.0"
-            }
-          }
-        },
-        "nslog": {
-          "version": "3.0.0",
-          "dependencies": {
-            "nan": {
-              "version": "2.2.0"
-            }
-          }
-        },
-        "promise": {
-          "version": "7.1.1",
-          "dependencies": {
-            "asap": {
-              "version": "2.0.3"
-            }
-          }
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "dependencies": {
-            "camelcase": {
-              "version": "2.1.0"
-            },
-            "cliui": {
-              "version": "3.1.0",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "wrap-ansi": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.1.2",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.4"
-                }
-              }
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "dependencies": {
-                "lcid": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "invert-kv": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "window-size": {
-              "version": "0.1.4"
-            },
-            "y18n": {
-              "version": "3.2.0"
-            }
-          }
-        }
-      }
-    },
-    "is-running": {
-      "version": "1.0.5"
-    },
-    "lucy-dirsum": {
-      "version": "https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz"
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8"
-        }
-      }
-    },
-    "ncp": {
-      "version": "2.0.0"
-    },
-    "rimraf": {
-      "version": "2.4.4",
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
                     }
                   }
                 }
@@ -2026,24 +2225,932 @@
             },
             "once": {
               "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "from": "once@>=1.3.3 <1.4.0"
+            },
+            "opener": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
+              "from": "opener@>=1.4.1 <1.5.0"
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "from": "osenv@0.1.3",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
+                  "from": "os-homedir@>=1.0.0 <2.0.0"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+              "from": "path-is-inside@1.0.1"
+            },
+            "read": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "from": "read@1.0.7",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "from": "mute-stream@>=0.0.4 <0.1.0"
+                }
+              }
+            },
+            "read-installed": {
+              "version": "4.0.3",
+              "from": "read-installed@4.0.3",
+              "dependencies": {
+                "debuglog": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+                  "from": "debuglog@>=1.0.1 <2.0.0"
+                },
+                "readdir-scoped-modules": {
+                  "version": "1.0.2",
+                  "from": "readdir-scoped-modules@>=1.0.0 <2.0.0"
+                },
+                "util-extend": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
+                  "from": "util-extend@>=1.0.1 <2.0.0"
+                }
+              }
+            },
+            "read-package-json": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.3.tgz",
+              "from": "read-package-json@2.0.3",
+              "dependencies": {
+                "glob": {
+                  "version": "6.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "from": "glob@>=6.0.0 <7.0.0",
+                  "dependencies": {
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "json-parse-helpfulerror": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
+                  "dependencies": {
+                    "jju": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz",
+                      "from": "jju@>=1.1.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@>=1.1.13 <1.2.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                }
+              }
+            },
+            "realize-package-specifier": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
+              "from": "realize-package-specifier@>=3.0.0 <3.1.0"
+            },
+            "request": {
+              "version": "2.69.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+              "from": "request@2.69.0",
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "from": "aws-sign2@>=0.6.0 <0.7.0"
+                },
+                "aws4": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
+                  "from": "aws4@>=1.2.1 <2.0.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "from": "lru-cache@>=2.6.5 <3.0.0"
+                    }
+                  }
+                },
+                "bl": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz",
+                  "from": "bl@>=1.0.0 <1.1.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "from": "caseless@>=0.11.0 <0.12.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "from": "combined-stream@>=1.0.5 <1.1.0",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "from": "extend@>=3.0.0 <3.1.0"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "from": "forever-agent@>=0.6.1 <0.7.0"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.2",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                      "from": "async@>=1.4.0 <2.0.0"
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "from": "har-validator@>=2.0.6 <2.1.0",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "from": "chalk@>=1.1.1 <2.0.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.4",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "from": "has-ansi@>=2.0.0 <3.0.0"
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "from": "supports-color@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "from": "commander@>=2.9.0 <3.0.0",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "from": "graceful-readlink@>=1.0.0"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.4",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+                      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "from": "generate-function@>=2.0.0 <3.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "from": "is-property@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                          "from": "jsonpointer@2.0.0"
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "from": "xtend@>=4.0.0 <5.0.0"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "from": "pinkie@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "from": "hawk@>=3.1.0 <3.2.0",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "from": "boom@>=2.0.0 <3.0.0"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "from": "cryptiles@>=2.0.0 <3.0.0"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "from": "hoek@>=2.0.0 <3.0.0"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "from": "sntp@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "from": "http-signature@>=1.1.0 <1.2.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "from": "assert-plus@>=0.2.0 <0.3.0"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                      "from": "jsprim@>=1.2.2 <2.0.0",
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "from": "extsprintf@1.0.2"
+                        },
+                        "json-schema": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                          "from": "json-schema@0.2.2"
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "from": "verror@1.3.6"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.3",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
+                      "from": "sshpk@>=1.7.0 <2.0.0",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "from": "asn1@>=0.2.3 <0.3.0"
+                        },
+                        "dashdash": {
+                          "version": "1.12.2",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
+                          "from": "dashdash@>=1.10.1 <2.0.0"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "from": "ecc-jsbn@>=0.0.1 <1.0.0"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "from": "jodid25519@>=1.0.0 <2.0.0"
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "from": "jsbn@>=0.1.0 <0.2.0"
+                        },
+                        "tweetnacl": {
+                          "version": "0.13.3",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                          "from": "tweetnacl@>=0.13.0 <1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "from": "is-typedarray@>=1.0.0 <1.1.0"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "from": "isstream@>=0.1.2 <0.2.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "2.1.9",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+                  "from": "mime-types@>=2.1.7 <2.2.0",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz",
+                      "from": "mime-db@>=1.21.0 <1.22.0"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "from": "node-uuid@>=1.4.7 <1.5.0"
+                },
+                "oauth-sign": {
+                  "version": "0.8.1",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0"
+                },
+                "qs": {
+                  "version": "6.0.2",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
+                  "from": "qs@>=6.0.2 <6.1.0"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                },
+                "tough-cookie": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+                  "from": "tough-cookie@>=2.2.0 <2.3.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+                  "from": "tunnel-agent@>=0.4.1 <0.5.0"
+                }
+              }
+            },
+            "retry": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
+              "from": "retry@0.9.0"
+            },
+            "rimraf": {
+              "version": "2.5.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.1.tgz",
+              "from": "rimraf@2.5.1",
+              "dependencies": {
+                "glob": {
+                  "version": "6.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "from": "glob@>=6.0.1 <7.0.0",
+                  "dependencies": {
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+              "from": "semver@>=5.1.0 <5.2.0"
+            },
+            "sha": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "from": "sha@2.0.1",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "slide": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "from": "slide@>=1.1.6 <1.2.0"
+            },
+            "sorted-object": {
+              "version": "1.0.0",
+              "from": "sorted-object@"
+            },
+            "spdx-license-ids": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
+              "from": "spdx-license-ids@1.2.0"
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "from": "strip-ansi@3.0.0"
+            },
+            "tar": {
+              "version": "2.2.1",
+              "from": "tar@2.2.1"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@~0.2.0"
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "from": "uid-number@>=0.0.6 <0.1.0"
+            },
+            "umask": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+              "from": "umask@>=1.1.0 <1.2.0"
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "from": "validate-npm-package-license@>=3.0.1 <3.1.0",
+              "dependencies": {
+                "spdx-correct": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                  "from": "spdx-correct@>=1.0.0 <1.1.0"
+                },
+                "spdx-expression-parse": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                  "dependencies": {
+                    "spdx-exceptions": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                      "from": "spdx-exceptions@>=1.0.4 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "validate-npm-package-name": {
+              "version": "2.2.2",
+              "from": "validate-npm-package-name@2.2.2",
+              "dependencies": {
+                "builtins": {
+                  "version": "0.0.7",
+                  "from": "builtins@0.0.7"
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+              "from": "which@1.2.4",
+              "dependencies": {
+                "is-absolute": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "dependencies": {
+                    "is-relative": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                      "from": "is-relative@>=0.1.0 <0.2.0"
+                    }
+                  }
+                },
+                "isexe": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.1.tgz",
+                  "from": "isexe@>=1.1.1 <2.0.0"
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "from": "wrappy@1.0.1"
+            },
+            "write-file-atomic": {
+              "version": "1.1.4",
+              "from": "write-file-atomic@>=1.1.4 <1.2.0"
+            }
+          }
+        },
+        "nslog": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/nslog/-/nslog-3.0.0.tgz",
+          "from": "https://registry.npmjs.org/nslog/-/nslog-3.0.0.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+            }
+          }
+        },
+        "promise": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+          "from": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+          "dependencies": {
+            "asap": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
+              "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+            }
+          }
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
+              "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+            },
+            "cliui": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
+              "from": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz",
+                  "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                }
+              }
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+              "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+              "dependencies": {
+                "lcid": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                  "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                  "dependencies": {
+                    "invert-kv": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "window-size": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+            },
+            "y18n": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
+              "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "is-running": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-running/-/is-running-1.0.5.tgz",
+      "from": "https://registry.npmjs.org/is-running/-/is-running-1.0.5.tgz"
+    },
+    "lucy-dirsum": {
+      "version": "0.1.1",
+      "resolved": "https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz",
+      "from": "https://github.com/mixmaxhq/lucy-dirsum/archive/08299b483cd0f79d18cd0fa1c5081dcab67c5649.tar.gz"
+    },
+    "meteor-build-client": {
+      "version": "0.3.0",
+      "resolved": "https://github.com/jarnoleconte/meteor-build-client/archive/2f470fc716544021ff9a98dca6c8f7610c736a48.tar.gz",
+      "from": "https://github.com/jarnoleconte/meteor-build-client/archive/2f470fc716544021ff9a98dca6c8f7610c736a48.tar.gz",
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "from": "commander@>=2.8.1 <3.0.0",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "from": "graceful-readlink@>=1.0.0"
+            }
+          }
+        },
+        "simple-spinner": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/simple-spinner/-/simple-spinner-0.0.3.tgz",
+          "from": "simple-spinner@0.0.3"
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "from": "underscore@>=1.8.3 <2.0.0"
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+    },
+    "rimraf": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1"
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         }
       }
     },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "url-join": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "from": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
     }
   }
 }

--- a/app/main.js
+++ b/app/main.js
@@ -99,9 +99,14 @@ if (electronSettings.updateFeedUrl) {
   };
 }
 
-var launchUrl = electronSettings.rootUrl;
-if (electronSettings.launchPath) {
-  launchUrl += electronSettings.launchPath;
+var launchUrl;
+if (electronSettings.autoPackage && electronSettings.bundleClient) {
+  launchUrl = 'file://' + __dirname + '/web/index.html';
+} else {
+  launchUrl = electronSettings.rootUrl;
+  if (electronSettings.launchPath) {
+    launchUrl += electronSettings.launchPath;
+  }
 }
 
 var windowOptions = {

--- a/package.js
+++ b/package.js
@@ -16,7 +16,8 @@ Npm.depends({
   "rimraf": "2.4.4",
   "semver": "5.1.0",
   "url-join": "0.0.1",
-  "electron-rebuild": "1.0.1"
+  "electron-rebuild": "1.0.1",
+  "meteor-build-client": "https://github.com/jarnoleconte/meteor-build-client/archive/2f470fc716544021ff9a98dca6c8f7610c736a48.tar.gz",
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
My first attempt to use meteor-electron to build offline apps. 

This will bundle meteor client code with the app. So instead of an external entry point `rootUrl` it will now have a single local entry file `index.html` (together with a `.js` and `.css` file) that serves the whole app. The packaged app is therefore self contained.

It relies on the package meteor-build-client which I have modified to run as node module. Originally it was a CLI only. Although that package needs some improvements. Error handling is not done very well, and there is little control over the executed commands which could lead to ghost processes. But I guess this could be improved over time. 

All you have to do is include `"bundleClient": true` in the electron settings.
