### PR TITLE
Added BrowserWindow options title, x and y.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Configuration is possible via `Meteor.settings.electron`. For example,
 {
   "electron": {
     "name": "MyApp",
+    "title": "MyApp",
     "icon": {
       "darwin": "private/MyApp.icns",
       "win32": "private/MyApp.ico"
@@ -46,6 +47,8 @@ Configuration is possible via `Meteor.settings.electron`. For example,
     "sign": "Developer ID Application: ...",
     "height": 768,
     "width": 1024,
+    "x": 100,
+    "y": 75,
     "frame": true,
     "title-bar-style": "hidden",
     "resizable": true,

--- a/app/main.js
+++ b/app/main.js
@@ -147,6 +147,18 @@ if (electronSettings.maxHeight) {
   windowOptions.maxHeight = electronSettings.maxHeight;
 }
 
+if (electronSettings.title) {
+  windowOptions.title = electronSettings.title;
+}
+
+if (electronSettings.x) {
+  windowOptions.x = electronSettings.x;
+}
+
+if (electronSettings.y) {
+  windowOptions.y = electronSettings.y;
+}
+
 if (electronSettings.frame === false){
   windowOptions.frame = false;
 }


### PR DESCRIPTION
Hi everybody,

The following modification makes options `title`, `x` and `y` available in the configuration file passed on startup with `--settings`. Updated the docs accordingly, but I wonder if the `title` option doesn't functionally conflict with the original `name`option (not sure if `name` is really used in the code).

Thank you very much for your work on this valuable package!
