### PR TITLE
Avoid error if mainWindow is no longer set when "activate" occurs.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -187,5 +187,7 @@ app.on("before-quit", function(){
 
 app.on("activate", function(){
   // Show the main window when the customer clicks on the app icon.
-  if (!mainWindow.isVisible()) mainWindow.show();
+  if (mainWindow && !mainWindow.isVisible()) {
+    mainWindow.show();
+  }
 });


### PR DESCRIPTION
Got this error when testing my electron app on OSX:

```
Uncaught Exception:
TypeError: Cannot read property 'isVisible' of undefined
    at promptIfAppropriate [as _repeat] (/Users/alanning/src/share911/app/.meteor-electron/darwin-x64/builds/Share911-darwin-x64/Share911.app/Contents/Resources/app.asar/loginSafeguards.js:75:36)
    at wrapper [as _onTimeout] (timers.js:275:19)
    at Timer.listOnTimeout (timers.js:92:15)
```

Not sure why activate would be called when mainWindow is not set though...
