### PR TITLE
add desktopCapturer api to enable screen capturing

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -109,6 +109,7 @@ var windowOptions = {
   height: electronSettings.height || 600,
   resizable: true,
   frame: true,
+  title: app.getName(),
   /**
    * Disable Electron's Node integration so that browser dependencies like `moment` will load themselves
    * like normal i.e. into the window rather than into modules, and also to prevent untrusted client

--- a/app/main.js
+++ b/app/main.js
@@ -170,6 +170,10 @@ app.on("ready", function(){
   // more quickly.
   mainWindow.on('close', hideInsteadofClose);
 
+  if (electronSettings.maximize) {
+    mainWindow.maximize();
+  }
+
   mainWindow.focus();
   mainWindow.loadURL(launchUrl);
 });

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "electron",
-  "productName": "Electron",
   "main": "main.js",
   "dependencies": {
     "electron-debug": "^0.5.1",

--- a/app/preload.js
+++ b/app/preload.js
@@ -12,6 +12,7 @@ var _ = require('underscore');
 var ipc = require('electron').ipcRenderer;
 var remote = require('electron').remote;
 var shell = require('electron').shell;
+var desktopCapturer = require('electron').desktopCapturer;
 
 /**
  * Defines methods with which to extend the `Electron` module defined in `client.js`.
@@ -81,5 +82,7 @@ ElectronImplementation = {
     listeners.push(callback);
   },
 
-  _eventListeners: {}
+  _eventListeners: {},
+
+  desktopCapturer: desktopCapturer,
 };

--- a/client/index.js
+++ b/client/index.js
@@ -52,7 +52,9 @@ Electron = {
    * @param {Function} callback - A function to invoke when `event` is triggered. Takes no arguments
    *   and returns no value.
    */
-  onWindowEvent: function() {}
+  onWindowEvent: function() {},
+
+  desktopCapturer: {}
 };
 
 // Read `ElectronImplementation` from the window vs. doing `typeof ElectronImplementation` because


### PR DESCRIPTION
This PR just exposes `Electrons` [desktopCapturer](https://github.com/electron/electron/blob/02ce727ff6f6d8afbc6235ab3e1bb127e765b2ab/docs/api/desktop-capturer.md) to make screen capturing possible.
