### PR TITLE
add desktopCapturer api to enable screen capturing

### DIFF
--- a/app/preload.js
+++ b/app/preload.js
@@ -12,6 +12,7 @@ var _ = require('underscore');
 var ipc = require('electron').ipcRenderer;
 var remote = require('electron').remote;
 var shell = require('electron').shell;
+var desktopCapturer = require('electron').desktopCapturer;
 
 /**
  * Defines methods with which to extend the `Electron` module defined in `client.js`.
@@ -81,5 +82,7 @@ ElectronImplementation = {
     listeners.push(callback);
   },
 
-  _eventListeners: {}
+  _eventListeners: {},
+
+  desktopCapturer: desktopCapturer,
 };

--- a/app/preload.js
+++ b/app/preload.js
@@ -84,5 +84,8 @@ ElectronImplementation = {
 
   _eventListeners: {},
 
+  /**
+   * Expose Electrons desktopCapturer API used to enable screen capture.
+   */
   desktopCapturer: desktopCapturer,
 };

--- a/client/index.js
+++ b/client/index.js
@@ -52,7 +52,9 @@ Electron = {
    * @param {Function} callback - A function to invoke when `event` is triggered. Takes no arguments
    *   and returns no value.
    */
-  onWindowEvent: function() {}
+  onWindowEvent: function() {},
+
+  desktopCapturer: {}
 };
 
 // Read `ElectronImplementation` from the window vs. doing `typeof ElectronImplementation` because

--- a/client/index.js
+++ b/client/index.js
@@ -54,6 +54,9 @@ Electron = {
    */
   onWindowEvent: function() {},
 
+  /**
+   * Expose Electrons desktopCapturer API used to enable screen capture.
+   */
   desktopCapturer: {}
 };
 


### PR DESCRIPTION
This PR just exposes `Electrons` [desktopCapturer](https://github.com/electron/electron/blob/02ce727ff6f6d8afbc6235ab3e1bb127e765b2ab/docs/api/desktop-capturer.md) to make screen capturing possible.
